### PR TITLE
Allow using an already installed QuantLib.

### DIFF
--- a/App/Makefile.am
+++ b/App/Makefile.am
@@ -7,14 +7,13 @@ bin_PROGRAMS = ore
 AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir} \
 	-I${top_builddir}/../OREAnalytics \
 	-I${top_builddir}/../OREData \
-	-I${top_builddir}/../QuantExt \
-	-I${top_builddir}/../QuantLib
+	-I${top_builddir}/../QuantExt
 
 AM_LDFLAGS = \
 	-L${top_builddir}/../OREAnalytics/orea -lOREAnalytics \
 	-L${top_builddir}/../OREData/ored -lOREData \
 	-L${top_builddir}/../QuantExt/qle -lQuantExt \
-	-L${top_builddir}/../QuantLib/ql -lQuantLib \
+	-lQuantLib \
 	-lboost_serialization -lboost_date_time -lboost_regex -lboost_filesystem -lboost_system
 
 LDADD =

--- a/App/configure.ac
+++ b/App/configure.ac
@@ -66,9 +66,20 @@ if test [ -n "$ql_boost_lib_path" ] ; then
 fi
 
 # QuantLib
-ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
-AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
-AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+
+AC_ARG_WITH([quantlib-prefix],
+            AC_HELP_STRING([--with-quantlib-prefix=PREFIX],
+                           [Supply the location of QuantLib if already installed]),
+            [ql_prefix="`cd ${withval} 2>/dev/null && pwd`"],
+            [])
+if test [ -n "$ql_prefix" ] ; then
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_prefix}/include"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_prefix}/lib"])
+else
+    ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+fi
 
 # Continue setup
 

--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -474,7 +474,17 @@ Alternatively, compile all Boost libraries directly from the source code:
 \% make -j4
 }
 
-This will build both the QuantExt library and test suite.
+This will build both the QuantExt library and test suite using the
+QuantLib code you compiled in the previous step.  If you already have
+an installed version of QuantLib on your machine and you want to use
+it, you can change the {\tt ./configure} command above to
+
+{\tt\footnotesize
+\% ./configure --with-quantlib-prefix=/usr/local
+}
+
+where you can replace {\tt /usr/local} with the path where you
+installed QuantLib.
 
 \item Run the test suite
 

--- a/OREAnalytics/configure.ac
+++ b/OREAnalytics/configure.ac
@@ -68,9 +68,20 @@ if test [ -n "$ql_boost_lib_path" ] ; then
 fi
 
 # QuantLib
-ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
-AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
-AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+
+AC_ARG_WITH([quantlib-prefix],
+            AC_HELP_STRING([--with-quantlib-prefix=PREFIX],
+                           [Supply the location of QuantLib if already installed]),
+            [ql_prefix="`cd ${withval} 2>/dev/null && pwd`"],
+            [])
+if test [ -n "$ql_prefix" ] ; then
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_prefix}/include"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_prefix}/lib"])
+else
+    ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+fi
 
 # Continue setup
 

--- a/OREData/configure.ac
+++ b/OREData/configure.ac
@@ -68,9 +68,20 @@ if test [ -n "$ql_boost_lib_path" ] ; then
 fi
 
 # QuantLib
-ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
-AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
-AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+
+AC_ARG_WITH([quantlib-prefix],
+            AC_HELP_STRING([--with-quantlib-prefix=PREFIX],
+                           [Supply the location of QuantLib if already installed]),
+            [ql_prefix="`cd ${withval} 2>/dev/null && pwd`"],
+            [])
+if test [ -n "$ql_prefix" ] ; then
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_prefix}/include"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_prefix}/lib"])
+else
+    ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+fi
 
 # Continue setup
 

--- a/QuantExt/configure.ac
+++ b/QuantExt/configure.ac
@@ -68,9 +68,20 @@ if test [ -n "$ql_boost_lib_path" ] ; then
 fi
 
 # QuantLib
-ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
-AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
-AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+
+AC_ARG_WITH([quantlib-prefix],
+            AC_HELP_STRING([--with-quantlib-prefix=PREFIX],
+                           [Supply the location of QuantLib if already installed]),
+            [ql_prefix="`cd ${withval} 2>/dev/null && pwd`"],
+            [])
+if test [ -n "$ql_prefix" ] ; then
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_prefix}/include"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_prefix}/lib"])
+else
+    ql_path="`cd ../QuantLib 2>/dev/null && pwd`"
+    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_path}"])
+    AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_path}/ql/.libs"])
+fi
 
 # Continue setup
 

--- a/QuantExt/test/analyticlgmswaptionengine.cpp
+++ b/QuantExt/test/analyticlgmswaptionengine.cpp
@@ -35,7 +35,7 @@
 #include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/time/calendars/target.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 #include <boost/make_shared.hpp>
 

--- a/QuantExt/test/crossassetmodel.cpp
+++ b/QuantExt/test/crossassetmodel.cpp
@@ -43,7 +43,7 @@
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/quotes/simplequote.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/accumulators/accumulators.hpp>

--- a/QuantExt/test/crossassetmodel2.cpp
+++ b/QuantExt/test/crossassetmodel2.cpp
@@ -39,7 +39,7 @@
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/quotes/simplequote.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 #include <boost/make_shared.hpp>
 #include <boost/accumulators/accumulators.hpp>

--- a/QuantExt/test/crossassetmodelparametrizations.cpp
+++ b/QuantExt/test/crossassetmodelparametrizations.cpp
@@ -27,7 +27,7 @@
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 #include <boost/make_shared.hpp>
 

--- a/QuantExt/test/dynamicblackvoltermstructure.cpp
+++ b/QuantExt/test/dynamicblackvoltermstructure.cpp
@@ -26,7 +26,7 @@
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/target.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 using namespace QuantExt;
 using namespace QuantLib;

--- a/QuantExt/test/dynamicswaptionvolmatrix.cpp
+++ b/QuantExt/test/dynamicswaptionvolmatrix.cpp
@@ -24,7 +24,7 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/quotes/simplequote.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 using namespace QuantExt;
 using namespace QuantLib;

--- a/QuantExt/test/staticallycorrectedyieldtermstructure.cpp
+++ b/QuantExt/test/staticallycorrectedyieldtermstructure.cpp
@@ -24,7 +24,7 @@
 #include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/quotes/simplequote.hpp>
 
-#include <test-suite/utilities.hpp>
+#include <test/utilities.hpp>
 
 #include <boost/make_shared.hpp>
 

--- a/QuantExt/test/utilities.hpp
+++ b/QuantExt/test/utilities.hpp
@@ -1,0 +1,55 @@
+/*
+ Copyright (C) 2003, 2004, 2008 StatPro Italia srl
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#ifndef quantext_test_utilities_hpp
+#define quantext_test_utilities_hpp
+
+// This makes it easier to use array literals
+#define LENGTH(a) (sizeof(a)/sizeof(a[0]))
+
+
+#define QUANTLIB_TEST_CASE(f) BOOST_TEST_CASE(QuantLib::detail::quantlib_test_case(f))
+
+namespace QuantLib {
+
+    namespace detail {
+
+        class quantlib_test_case {
+            boost::function0<void> test_;
+          public:
+            template <class F>
+            quantlib_test_case(F test) : test_(test) {}
+            void operator()() const {
+                Date before = Settings::instance().evaluationDate();
+                BOOST_CHECK(true);
+                test_();
+                Date after = Settings::instance().evaluationDate();
+                if (before != after)
+                    BOOST_ERROR("Evaluation date not reset"
+                                << "\n  before: " << before
+                                << "\n  after:  " << after);
+            }
+        };
+
+    }
+
+}
+
+
+#endif
+


### PR DESCRIPTION
Running `./configure --with-quantlib-prefix=PREFIX` will add
`-I PREFIX/include` to `CXXFLAGS` and `-L PREFIX/lib to LDFLAGS`.

The installation needs to be made with `make install`; pointing
to where you downloaded or cloned QuantLib won't work.
