### PR TITLE
Compatibility with QuantLib 1.15

### DIFF
--- a/OREAnalytics/orea/aggregation/postprocess.cpp
+++ b/OREAnalytics/orea/aggregation/postprocess.cpp
@@ -935,7 +935,7 @@ void PostProcess::dynamicInitialMargin() {
     LsmBasisSystem::PolynomType polynomType = LsmBasisSystem::Monomial;
     Size regressionDimension = dimRegressors_.empty() ? 1 : dimRegressors_.size();
     LOG("DIM regression dimension = " << regressionDimension);
-    std::vector<boost::function1<Real, Array>> v(
+    std::vector<ext::function<Real(Array)>> v(
         LsmBasisSystem::multiPathBasisSystem(regressionDimension, polynomOrder, polynomType));
     Real confidenceLevel = QuantLib::InverseCumulativeNormal()(dimQuantile_);
     LOG("DIM confidence level " << confidenceLevel);

--- a/QuantExt/qle/indexes/inflationindexwrapper.cpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.cpp
@@ -107,10 +107,14 @@ void YoYInflationCouponPricer2::initialize(const InflationCoupon& coupon) {
     // use yield curve from index (which sets discount)
 
     discount_ = 1.0;
-    if (paymentDate_ > rateCurve_->referenceDate())
-        discount_ = rateCurve_->discount(paymentDate_);
-
-    spreadLegValue_ = spread_ * coupon_->accrualPeriod() * discount_;
+    if (paymentDate_ > rateCurve_->referenceDate()) {
+        if (rateCurve_.empty()) {
+            // allow to extract rates, but mark the discount as invalid for prices
+            discount_ = Null<Real>();
+        } else {
+            discount_ = rateCurve_->discount(paymentDate_);
+        }
+    }
 }
 
 } // namespace QuantExt

--- a/QuantExt/test/stabilisedglls.cpp
+++ b/QuantExt/test/stabilisedglls.cpp
@@ -1125,7 +1125,7 @@ BOOST_AUTO_TEST_CASE(test2DRegression) {
         y.push_back(yt);
     }
 
-    std::vector<boost::function1<Real, Array> > basis =
+    std::vector<ext::function<Real(Array)> > basis =
         LsmBasisSystem::multiPathBasisSystem(2, 2, LsmBasisSystem::Monomial);
 
     StabilisedGLLS m(x, y, basis, StabilisedGLLS::MaxAbs);


### PR DESCRIPTION
These are three minor edits to make ORE compatible with QuantLib 1.15

For the changes to inflationindexwrapper I've used this commit as a reference:
https://github.com/lballabio/QuantLib/commit/a3f003b8ba8a7d6f9dc3727da7c29e0bb9c417d7#diff-54442c6c948fc489c7811974da4ea87eL134

In two other places, references to boost::function1 are replaced with ext::function, which depends on <ql/function.hpp>, which was only recently added to QuantLib, potentially hindering backwards compatibility of ORE with older versions of QL. 