### PR TITLE
[chore] Fix warning in CMakeLists.txt conditionals regarding BUILD_DOC

### DIFF
--- a/OREAnalytics/doc/CMakeLists.txt
+++ b/OREAnalytics/doc/CMakeLists.txt
@@ -15,6 +15,6 @@ if (DOXYGEN_FOUND AND BUILD_DOC)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM )
-else (DOXYGEN_FOUND)
+else (DOXYGEN_FOUND AND BUILD_DOC)
   message("Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
+endif (DOXYGEN_FOUND AND BUILD_DOC)

--- a/OREData/doc/CMakeLists.txt
+++ b/OREData/doc/CMakeLists.txt
@@ -15,6 +15,6 @@ if (DOXYGEN_FOUND AND BUILD_DOC)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM )
-else (DOXYGEN_FOUND)
+else (DOXYGEN_FOUND AND BUILD_DOC)
   message("Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
+endif (DOXYGEN_FOUND AND BUILD_DOC)

--- a/QuantExt/doc/CMakeLists.txt
+++ b/QuantExt/doc/CMakeLists.txt
@@ -15,6 +15,6 @@ if (DOXYGEN_FOUND AND BUILD_DOC)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM )
-else (DOXYGEN_FOUND)
+else (DOXYGEN_FOUND AND BUILD_DOC)
   message("Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
+endif (DOXYGEN_FOUND AND BUILD_DOC)


### PR DESCRIPTION
Make the `else` and `endif` commands' arguments match the according `if` command arguments.

Note that from CMake version 3.14 this requirement is marked as "legacy": https://cmake.org/cmake/help/v3.14/command/if.html

I did not want to raise the `cmake_minimum_required` however, for obvious reasons.