### PR TITLE
[chore] Add austria.hpp to QuantExt_HDR in CMakeLists.txt

### DIFF
--- a/QuantExt/qle/CMakeLists.txt
+++ b/QuantExt/qle/CMakeLists.txt
@@ -151,6 +151,7 @@ time/yearcounter.cpp)
 # hpp files, this list is maintained manually
 
 set(QuantExt_HDR auto_link.hpp
+calendars/austria.hpp
 calendars/chile.hpp
 calendars/colombia.hpp
 calendars/france.hpp


### PR DESCRIPTION
Add `calendars/austria.hpp` to the `QuantExt_HDR` list.

The `writeAll` macro in the same file uses this list to write `qle/quantext.hpp`.

With this include missing, a rerun of cmake would therefore remove the Austria calendar from the aggregated includes.