### PR TITLE
[fix] Initialisation of real number and bool variables 

### DIFF
--- a/QuantExt/qle/cashflows/equitycoupon.hpp
+++ b/QuantExt/qle/cashflows/equitycoupon.hpp
@@ -49,7 +49,7 @@ public:
     EquityCoupon(const Date& paymentDate, Real nominal, const Date& startDate, const Date& endDate, Natural fixingDays,
                  const boost::shared_ptr<EquityIndex>& equityCurve, const DayCounter& dayCounter,
                  bool isTotalReturn = false, Real dividendFactor = 1.0, bool notionalReset = false, 
-                 Real initialPrice = Real(), Real quantity = Real(),
+                 Real initialPrice = Null<Real>(), Real quantity = Null<Real>(),
                  const Date& refPeriodStart = Date(), const Date& refPeriodEnd = Date(), 
                  const Date& exCouponDate = Date());
 


### PR DESCRIPTION
I noticed some issues with members of EquityCoupon and EquityLeg initialised to `Real()`. 

Please have a look at the following suggestion / summary:

Apparently, on some platforms (gcc 9.3.1/ Linux x86_64) the conditional 

```
if (initialPrice_)
```
would be evaluated `true`, resulting in weird pricing errors.

The same is true for omitting the initialisation of the `bool` member `notionalReset_` in `EquityLeg`. It is not necessarily `false` by default (https://stackoverflow.com/questions/4622225/boolean-variables-arent-always-false-by-default) which probably was the intention.


Augmented the according test case in the same manner as it has been set up before (enumerating instances of `EquityCouponPricer` for example). As far as I understand the implemenation, a `EquityCouponPricer` would be reinitialised upon each call to `rate()` in the `EquityCoupon`, would it not? So it is debatable whether creating six instances is actually necessary, but maybe this is not a big issue in test case.

