### PR TITLE
Patch of AtmStrike dereferencing bug

### DIFF
--- a/OREData/ored/marketdata/strike.cpp
+++ b/OREData/ored/marketdata/strike.cpp
@@ -141,8 +141,8 @@ string AtmStrike::toString() const {
 
 bool AtmStrike::equal_to(const BaseStrike& other) const {
     if (const AtmStrike* p = dynamic_cast<const AtmStrike*>(&other)) {
-        return !(atmType_ != p->atmType() || (deltaType_ && !p->deltaType()) || (!deltaType_ && p->deltaType()) ||
-                 *deltaType_ != *p->deltaType());
+        return (atmType_ == p->atmType()) &&
+               ((!deltaType_ && !p->deltaType()) || (deltaType_ && p->deltaType() && (*deltaType_ == *p->deltaType())));
     } else {
         return false;
     }

--- a/OREData/ored/marketdata/strike.cpp
+++ b/OREData/ored/marketdata/strike.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2019 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library

--- a/OREData/test/strike.cpp
+++ b/OREData/test/strike.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(testAtmStrikeNoDeltaEquality) {
     vector<boost::shared_ptr<BaseStrike>> strikes;
     strikes.push_back(boost::make_shared<AtmStrike>(atmType, atmDeltaType));
     strikes.push_back(boost::make_shared<AtmStrike>(DeltaVolQuote::AtmFwd));
-    BOOST_REQUIRE(*strikes[0] == *strikes[1]);
+    BOOST_CHECK(*strikes[0] == *strikes[1]);
 }
 
 BOOST_AUTO_TEST_CASE(testAtmStrikeWithDelta) {

--- a/OREData/test/strike.cpp
+++ b/OREData/test/strike.cpp
@@ -113,6 +113,20 @@ BOOST_AUTO_TEST_CASE(testAtmStrikeNoDelta) {
     BOOST_CHECK(!castStrike->deltaType());
 }
 
+BOOST_AUTO_TEST_CASE(testAtmStrikeNoDeltaEquality) {
+
+    BOOST_TEST_MESSAGE("Testing equality operator for two ATM strikes without delta...");
+    // Checks for failure in operator== if delta type is not given
+
+    DeltaVolQuote::AtmType atmType = DeltaVolQuote::AtmFwd;
+    boost::optional<DeltaVolQuote::DeltaType> atmDeltaType;
+
+    vector<boost::shared_ptr<BaseStrike>> strikes;
+    strikes.push_back(boost::make_shared<AtmStrike>(atmType, atmDeltaType));
+    strikes.push_back(boost::make_shared<AtmStrike>(DeltaVolQuote::AtmFwd));
+    BOOST_REQUIRE(*strikes[0] == *strikes[1]);
+}
+
 BOOST_AUTO_TEST_CASE(testAtmStrikeWithDelta) {
 
     BOOST_TEST_MESSAGE("Testing ATM strike with delta...");

--- a/OREData/test/strike.cpp
+++ b/OREData/test/strike.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2019 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library


### PR DESCRIPTION
Hi,
We ran into issues with the commodity delta volatility surface due to the ```AtmStrike::equal_to()``` function. Currently, this throws an exception if ```deltaType_``` is not initialized when dereferenced and fails on lines [711--712](https://github.com/OpenSourceRisk/Engine/blob/a5ee0fc09d5a50ab36e50d55893b6e484d6e7004/OREData/ored/marketdata/commodityvolcurve.cpp#L711) (or [721--722](https://github.com/OpenSourceRisk/Engine/blob/a5ee0fc09d5a50ab36e50d55893b6e484d6e7004/OREData/ored/marketdata/commodityvolcurve.cpp#L721), equivalently) of  ```CommodityVolCurve::buildVolatility(...)```. We change the return statement to not dereference should the variable not be initialized, giving it the intended functionality. The unit test _testAtmStrikeNoDeltaEquality_ is added to verify the correctness of the updated function. 

We're intending to send a series of PRs, as discussed with Roland Lichters, and will be very happy to receive feedback or other suggestions. 

Best regards,
Fredrik Gerdin Börjesson,
SEB

Edit: Changed typo of moneyness surface -> delta surface, updated referenced lines of code. 