### PR TITLE
Hermite interpolation added for commodity curves

### DIFF
--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -5161,7 +5161,7 @@ as 'Optional', then it may be excluded or included and left blank.
 \item Quotes: forward price quotes. These can be a futures price or forward points.
 \item DayCounter: The day count basis used internally by the curve to calculate the time between dates.
 \item InterpolationMethod [Optional]: The variable on which the interpolation is performed. The allowable values are
-Linear, LogLinear, Cubic, LinearFlat, LogLinearFlat, CubicFlat. This is different to yield curves above in that Flat versions
+Linear, LogLinear, Cubic, Hermite, LinearFlat, LogLinearFlat, CubicFlat, HermiteFlat. This is different to yield curves above in that Flat versions
 of the standard methods are defined, with each of these if there is no Spot price than any extrapolation between $T_0$ and the
 first future price will be flat (i.e. the first future price will be copied back "Flat" to $T_0$). 
 If the element is omitted or left blank, then it defaults to \emph{Linear}.

--- a/OREData/ored/marketdata/commoditycurve.hpp
+++ b/OREData/ored/marketdata/commoditycurve.hpp
@@ -127,6 +127,9 @@ template <template <class> class CurveType, typename... Args> void CommodityCurv
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::LogLinearFlat>>(args...);
     } else if (interpolationMethod_ == "CubicFlat") {
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::CubicFlat>>(args...);
+    } else if (interpolationMethod_ == "Hermite" || interpolationMethod_ == "CubicParabolic") {
+        commodityPriceCurve_ =
+            boost::make_shared<CurveType<QuantLib::Cubic>>(args..., QuantLib::Cubic(QuantLib::CubicInterpolation::Parabolic));
     } else {
         QL_FAIL("The interpolation method, " << interpolationMethod_ << ", is not supported.");
     }

--- a/OREData/ored/marketdata/commoditycurve.hpp
+++ b/OREData/ored/marketdata/commoditycurve.hpp
@@ -122,15 +122,17 @@ template <template <class> class CurveType, typename... Args> void CommodityCurv
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantLib::LogLinear>>(args...);
     } else if (interpolationMethod_ == "Cubic") {
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantLib::Cubic>>(args...);
+    } else if (interpolationMethod_ == "Hermite") {
+        commodityPriceCurve_ = boost::make_shared<CurveType<QuantLib::Cubic>>(
+            args..., QuantLib::Cubic(QuantLib::CubicInterpolation::Parabolic));
     } else if (interpolationMethod_ == "LinearFlat") {
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::LinearFlat>>(args...);
     } else if (interpolationMethod_ == "LogLinearFlat") {
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::LogLinearFlat>>(args...);
     } else if (interpolationMethod_ == "CubicFlat") {
         commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::CubicFlat>>(args...);
-    } else if (interpolationMethod_ == "Hermite" || interpolationMethod_ == "CubicParabolic") {
-        commodityPriceCurve_ =
-            boost::make_shared<CurveType<QuantLib::Cubic>>(args..., QuantLib::Cubic(QuantLib::CubicInterpolation::Parabolic));
+    } else if (interpolationMethod_ == "HermiteFlat") {
+        commodityPriceCurve_ = boost::make_shared<CurveType<QuantExt::HermiteFlat>>(args...);
     } else {
         QL_FAIL("The interpolation method, " << interpolationMethod_ << ", is not supported.");
     }

--- a/OREData/ored/marketdata/commoditycurve.hpp
+++ b/OREData/ored/marketdata/commoditycurve.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2018 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library

--- a/QuantExt/qle/math/flatextrapolation.hpp
+++ b/QuantExt/qle/math/flatextrapolation.hpp
@@ -143,6 +143,16 @@ private:
     QuantLib::Real rightValue_;
 };
 
+//! Hermite interpolation and flat extrapolation factory and traits
+class HermiteFlat {
+public:
+    template <class I1, class I2> Interpolation interpolate(const I1& xBegin, const I1& xEnd, const I2& yBegin) const {
+        return FlatExtrapolation(boost::make_shared<Parabolic>(xBegin, xEnd, yBegin));
+    }
+    static const bool global = false;
+    static const Size requiredPoints = 2;
+};
+
 } // namespace QuantExt
 
 #endif


### PR DESCRIPTION
Hi,
We have had a need of Hermite interpolation for commodity price curves and have added this as an option. It can be toggled by either _"Hermite"_ or _"CubicParabolic"_, although I'd probably suggest excluding the latter for clarity. We have not added test coverage but internal testing has been performed and, additionally, we are basing the change on a previously purchased Quaternion patch for other curve types. 

Best regards,
Fredrik Gerdin Börjesson,
SEB