### PR TITLE
Additions to user guide

### DIFF
--- a/Docs/UserGuide/fixingdata.tex
+++ b/Docs/UserGuide/fixingdata.tex
@@ -147,7 +147,7 @@ DOM             & Any supported currency code \\
 \hline
 \textbf{Index Component} & \textbf{Allowable Values} \\
 \hline
-NAME           & \textit{\begin{tabular}[c]{@{}l@{}}EUHICP\\ EUHICPXT\\ FRHICP\\ UKRPI\\ 
+NAME           & \textit{\begin{tabular}[c]{@{}l@{}}CACPI\\ DKCPI\\ EUHICP\\ EUHICPXT\\ FRHICP\\ SECPI\\ UKRPI\\ 
 		USCPI\\ ZACPI \end{tabular}} \\ 
 \hline
 \end{tabular}

--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -3327,7 +3327,7 @@ following is an overview over the Example section's {\tt pricingengine.xml}. Fur
     </EngineParameters>
   </Product>
   <GlobalParameters>
-    <Parameter name="ContinueOnCalibrationError>true</Parameter>
+    <Parameter name="ContinueOnCalibrationError">true</Parameter>
   </GlobalParameters>
 \end{minted}
 \caption{Pricing engine configuration}

--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -4443,18 +4443,29 @@ Listing \ref{lst:eqcurve_configuration} shows the configuration of equity forwar
     <CurveDescription>SP 500 equity price projection curve</CurveDescription>
     <Currency>USD</Currency>
     <ForecastingCurve>EUR1D</ForecastingCurve>
-    <!-- DividendYield, ForwardPrice, OptionPremium -->
+    <!-- DividendYield, ForwardPrice, OptionPremium, NoDividends -->
     <Type>DividendYield</Type> 
     <!-- Optional node, only used when Type is OptionPremium -->
     <ExerciseStyle>American</ExerciseStyle>
     <!-- Spot quote from the market data file -->
     <SpotQuote>EQUITY/PRICE/SP5/USD</SpotQuote> 
+    <!-- Note: do not provide Quotes if Type is NoDividends -->
     <Quotes>
       <Quote>EQUITY_DIVIDEND/RATE/SP5/USD/3M</Quote>
       <Quote>EQUITY_DIVIDEND/RATE/SP5/USD/20160915</Quote>
       <Quote>EQUITY_DIVIDEND/RATE/SP5/USD/1Y</Quote>
       <Quote>EQUITY_DIVIDEND/RATE/SP5/USD/20170915</Quote>
     </Quotes>
+    <!-- Optional interpolation options, default Zero and Linear -->
+    <!-- Note: do not provide DividendInterpolation if Type is NoDividends -->
+    <DividendInterpolation>
+      <!-- Zero, Discount -->
+      <InterpolationVariable>Zero</InterpolationVariable>
+      <!-- See \ref{tab:allow_interp_methods} -->
+      <InterpolationMethod>LogLinear</InterpolationMethod>
+    </DividendInterpolation>
+    <!-- Optional node, defaults to true -->
+    <Extrapolation>True</Extrapolation>
     <DayCounter>A365</DayCounter>
   </EquityCurve>
   <EquityCurve>


### PR DESCRIPTION
Hi,
We have added some missing options to a table of the ZC inflation indices and additional options the example for EquityCurve configurations. We also correct a missing quote (") to allow for correct usage and syntax highlighting. This aims to check off some of the issues noted in #70. 

Best regards,
Fredrik Gerdin Börjesson,
SEB