### PR TITLE
Commodity/Equity/FX Asian option trade support

### DIFF
--- a/OREData/OREData.vcxproj
+++ b/OREData/OREData.vcxproj
@@ -35,6 +35,12 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ored\portfolio\builders\asianoption.hpp" />
+    <ClInclude Include="ored\portfolio\builders\commodityasianoption.hpp" />
+    <ClInclude Include="ored\portfolio\builders\equityasianoption.hpp" />
+    <ClInclude Include="ored\portfolio\builders\fxasianoption.hpp" />
+    <ClInclude Include="ored\portfolio\commodityasianoption.hpp" />
+    <ClInclude Include="ored\portfolio\equityasianoption.hpp" />
     <ClInclude Include="ored\auto_link.hpp" />
     <ClInclude Include="ored\configuration\basecorrelationcurveconfig.hpp" />
     <ClInclude Include="ored\configuration\bootstrapconfig.hpp" />
@@ -110,6 +116,7 @@
     <ClInclude Include="ored\model\structuredmodelerror.hpp" />
     <ClInclude Include="ored\model\utilities.hpp" />
     <ClInclude Include="ored\ored.hpp" />
+    <ClInclude Include="ored\portfolio\asianoption.hpp" />
     <ClInclude Include="ored\portfolio\bond.hpp" />
     <ClInclude Include="ored\portfolio\bondutils.hpp" />
     <ClInclude Include="ored\portfolio\builders\bond.hpp" />
@@ -148,6 +155,7 @@
     <ClInclude Include="ored\portfolio\fixingdates.hpp" />
     <ClInclude Include="ored\portfolio\forwardbond.hpp" />
     <ClInclude Include="ored\portfolio\forwardrateagreement.hpp" />
+    <ClInclude Include="ored\portfolio\fxasianoption.hpp" />
     <ClInclude Include="ored\portfolio\fxforward.hpp" />
     <ClInclude Include="ored\portfolio\fxoption.hpp" />
     <ClInclude Include="ored\portfolio\fxswap.hpp" />
@@ -158,6 +166,7 @@
     <ClInclude Include="ored\portfolio\legdatafactory.hpp" />
     <ClInclude Include="ored\portfolio\nettingsetdefinition.hpp" />
     <ClInclude Include="ored\portfolio\nettingsetmanager.hpp" />
+    <ClInclude Include="ored\portfolio\optionasiandata.hpp" />
     <ClInclude Include="ored\portfolio\optiondata.hpp" />
     <ClInclude Include="ored\portfolio\optionexercisedata.hpp" />
     <ClInclude Include="ored\portfolio\optionpaymentdata.hpp" />
@@ -265,6 +274,7 @@
     <ClCompile Include="ored\model\lgmbuilder.cpp" />
     <ClCompile Include="ored\model\lgmdata.cpp" />
     <ClCompile Include="ored\model\utilities.cpp" />
+    <ClCompile Include="ored\portfolio\asianoption.cpp" />
     <ClCompile Include="ored\portfolio\bond.cpp" />
     <ClCompile Include="ored\portfolio\bondutils.cpp" />
     <ClCompile Include="ored\portfolio\builders\capfloor.cpp" />
@@ -276,6 +286,7 @@
     <ClCompile Include="ored\portfolio\builders\swaption.cpp" />
     <ClCompile Include="ored\portfolio\builders\yoycapfloor.cpp" />
     <ClCompile Include="ored\portfolio\capfloor.cpp" />
+    <ClCompile Include="ored\portfolio\commodityasianoption.cpp" />
     <ClCompile Include="ored\portfolio\commodityforward.cpp" />
     <ClCompile Include="ored\portfolio\commodityoption.cpp" />
     <ClCompile Include="ored\portfolio\creditdefaultswap.cpp" />
@@ -283,12 +294,14 @@
     <ClCompile Include="ored\portfolio\enginedata.cpp" />
     <ClCompile Include="ored\portfolio\enginefactory.cpp" />
     <ClCompile Include="ored\portfolio\envelope.cpp" />
+    <ClCompile Include="ored\portfolio\equityasianoption.cpp" />
     <ClCompile Include="ored\portfolio\equityforward.cpp" />
     <ClCompile Include="ored\portfolio\equityoption.cpp" />
     <ClCompile Include="ored\portfolio\equityswap.cpp" />
     <ClCompile Include="ored\portfolio\fixingdates.cpp" />
     <ClCompile Include="ored\portfolio\forwardbond.cpp" />
     <ClCompile Include="ored\portfolio\forwardrateagreement.cpp" />
+    <ClCompile Include="ored\portfolio\fxasianoption.cpp" />
     <ClCompile Include="ored\portfolio\fxforward.cpp" />
     <ClCompile Include="ored\portfolio\fxoption.cpp" />
     <ClCompile Include="ored\portfolio\fxswap.cpp" />
@@ -298,6 +311,7 @@
     <ClCompile Include="ored\portfolio\legdatafactory.cpp" />
     <ClCompile Include="ored\portfolio\nettingsetdefinition.cpp" />
     <ClCompile Include="ored\portfolio\nettingsetmanager.cpp" />
+    <ClCompile Include="ored\portfolio\optionasiandata.cpp" />
     <ClCompile Include="ored\portfolio\optiondata.cpp" />
     <ClCompile Include="ored\portfolio\optionexercisedata.cpp" />
     <ClCompile Include="ored\portfolio\optionpaymentdata.cpp" />

--- a/OREData/OREData.vcxproj.filters
+++ b/OREData/OREData.vcxproj.filters
@@ -510,6 +510,33 @@
     <ClInclude Include="ored\portfolio\optionexercisedata.hpp">
       <Filter>portfolio</Filter>
     </ClInclude>
+    <ClInclude Include="ored\portfolio\asianoption.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\optionasiandata.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\equityasianoption.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\asianoption.hpp">
+      <Filter>portfolio\builders</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\equityasianoption.hpp">
+      <Filter>portfolio\builders</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\commodityasianoption.hpp">
+      <Filter>portfolio\builders</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\fxasianoption.hpp">
+      <Filter>portfolio\builders</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\fxasianoption.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\commodityasianoption.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ored\configuration\capfloorvolcurveconfig.cpp">
@@ -897,6 +924,21 @@
       <Filter>portfolio</Filter>
     </ClCompile>
     <ClCompile Include="ored\portfolio\optionexercisedata.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\asianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\optionasiandata.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\equityasianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\commodityasianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\fxasianoption.cpp">
       <Filter>portfolio</Filter>
     </ClCompile>
   </ItemGroup>

--- a/OREData/ored/portfolio/asianoption.cpp
+++ b/OREData/ored/portfolio/asianoption.cpp
@@ -1,0 +1,215 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+*/
+
+/*! \file ored/portfolio/asianoption.hpp
+\brief Asian option representation
+\ingroup tradedata
+*/
+
+#include <ored/portfolio/builders/asianoption.hpp>
+#include <ored/portfolio/asianoption.hpp>
+#include <ored/portfolio/optionwrapper.hpp>
+#include <ored/utilities/log.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/instruments/averagetype.hpp>
+#include <ql/errors.hpp>
+
+namespace ore {
+namespace data {
+
+void AsianOptionTrade::build(const boost::shared_ptr<EngineFactory>& engineFactory) {
+    QuantLib::Date today = engineFactory->market()->asofDate();
+    Currency ccy = parseCurrency(currency_);
+
+    QL_REQUIRE(tradeActions().empty(), "TradeActions not supported for AsianOption");
+
+    // Payoff
+    Option::Type type = parseOptionType(option_.callPut());
+    boost::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike_));
+
+    QuantLib::Exercise::Type exerciseType = parseExerciseType(option_.style());
+    QL_REQUIRE(option_.exerciseDates().size() == 1, "Invalid number of excercise dates");
+    expiryDate_ = parseDate(option_.exerciseDates().front());
+
+    // Set the maturity date equal to the expiry date. It may get updated below if option is cash settled with
+    // payment after expiry.
+    maturity_ = expiryDate_;
+
+    // Exercise
+    boost::shared_ptr<Exercise> exercise;
+    switch (exerciseType) {
+    case QuantLib::Exercise::Type::European: {
+        exercise = boost::make_shared<EuropeanExercise>(expiryDate_);
+        break;
+    }
+    case QuantLib::Exercise::Type::American: {
+        ELOG("The implemented Asian pricing engines do not support American options.");
+        QL_FAIL("The implemented Asian pricing engines do not support American options.");
+        //exercise = boost::make_shared<AmericanExercise>(expiryDate_, option_.payoffAtExpiry());
+        break;
+    }
+    default:
+        QL_FAIL("Option style " << option_.style() << " is not supported");
+    }
+
+    // Create the instrument and the populate the name for the engine builder.
+    boost::shared_ptr<Instrument> asian;
+    string tradeTypeBuilder = tradeType_;
+    tradeTypeBuilder += (exerciseType == Exercise::European) ? "" : "American";
+    Settlement::Type settlementType = parseSettlementType(option_.settlement());
+
+    bool isEuropDeferredCS = false;
+    if (exerciseType == Exercise::European && settlementType == Settlement::Cash) {
+        // We have a European cash-settled option
+
+        // Get payment data
+        const boost::optional<OptionPaymentData>& opd = option_.paymentData();
+        Date paymentDate = expiryDate_;
+        if (opd) {
+            if (opd->rulesBased()) {
+                const Calendar& cal = opd->calendar();
+                QL_REQUIRE(cal != Calendar(), "Need non-empty calendar for rules based payment date.");
+                paymentDate = cal.advance(expiryDate_, opd->lag(), Days, opd->convention());
+            } else {
+                const vector<Date>& dates = opd->dates();
+                QL_REQUIRE(dates.size() == 1, "Need exactly one payment date for cash settled European option.");
+                paymentDate = dates[0];
+            }
+            QL_REQUIRE(paymentDate >= expiryDate_, "Payment date must be greater than or equal to expiry date.");
+        }
+        
+        if (paymentDate > expiryDate_) {
+            isEuropDeferredCS = true;
+            tradeTypeBuilder += "EuropeanCS";
+            // TODO: If support is needed/added, add logic from ored/portfolio/vanillaoption.cpp for updating of maturity date.
+            ELOG("Asian options do not support deferred cash settlement payments, "
+                 << "i.e. where payment date > maturity date.");
+            QL_FAIL("Asian options do not support deferred cash-settlement payments, i.e. where payment date > "
+                    "maturity date.");
+        }
+    }
+
+    // Create builder in advance to determine if continuous or discrete asian option.
+    Average::Type averageType = option_.asianData()->averageType();
+    OptionAsianData::AsianType asianType = option_.asianData()->asianType();
+    tradeTypeBuilder += to_string(averageType); // Add Arithmetic/Geometric
+    tradeTypeBuilder += to_string(asianType);   // Add Price/Strike
+    boost::shared_ptr<EngineBuilder> builder = engineFactory->builder(tradeTypeBuilder);
+    QL_REQUIRE(builder, "No builder found for " << tradeTypeBuilder);
+    // TODO: Add check for processType tag in advance?
+    std::string processType = engineFactory->engineData()->engineParameters(tradeTypeBuilder).at("ProcessType");
+    QL_REQUIRE(processType != "", "ProcessType must be configured.");
+
+    if (!isEuropDeferredCS) {
+        // If the option is not a European deferred CS contract, i.e. the standard European/American physical/cash-settled ones. 
+        if (processType == "Discrete") {
+            Real runningAccumulator = 0;
+            if (averageType == Average::Type::Geometric) {
+                runningAccumulator = 1;
+            }
+            Size pastFixings = 0;
+            std::vector<QuantLib::Date> fixingDates = option_.asianData()->fixingDates();
+            // Sort for the engine's sake
+            std::sort(fixingDates.begin(), fixingDates.end());
+            std::vector<QuantLib::Date> futureFixingDates;
+
+            QL_REQUIRE(index_, "Asian option trade " << id() << " needs a valid index for historical fixings.");
+            // If index name has not been populated, use logic here to populate it from the index object.
+            string indexName = indexName_;
+            if (indexName.empty()) {
+                indexName = index_->name();
+                if (assetClassUnderlying_ == AssetClass::EQ)
+                    indexName = "EQ-" + indexName;
+            }
+            for (QuantLib::Date fixingDate : fixingDates) {
+                if (fixingDate < today ||
+                    (fixingDate == today && Settings::instance().enforcesTodaysHistoricFixings())) {
+                    requiredFixings_.addFixingDate(fixingDate, indexName);
+                    Real fixingValue = index_->fixing(fixingDate);
+                    if (averageType == Average::Type::Geometric) {
+                        runningAccumulator *= fixingValue;
+                    } else if (averageType == Average::Type::Arithmetic) {
+                        runningAccumulator += fixingValue;
+                    }
+                    ++pastFixings;
+                } else { // Only pass future dates to engine
+                    futureFixingDates.push_back(fixingDate);
+                }
+            }
+
+            asian = boost::make_shared<QuantLib::DiscreteAveragingAsianOption>(
+                averageType, runningAccumulator, pastFixings, fixingDates, payoff, exercise);
+        } else if (processType == "Continuous") {
+            asian = boost::make_shared<QuantLib::ContinuousAveragingAsianOption>(averageType, payoff, exercise);
+        }
+    } else {
+        ELOG("Asian options do not support deferred cash settlement payments, "
+             << "i.e. where payment date > maturity date.");
+        QL_FAIL("Asian options do not support deferred cash-settlement payments, i.e. where payment date > "
+                << "maturity date.");
+    }
+
+
+    // Only try to set an engine on the option instrument if it is not expired. This avoids errors in
+    // engine builders that rely on the expiry date being in the future.
+    string configuration = Market::defaultConfiguration;
+    if (!asian->isExpired()) {
+        boost::shared_ptr<AsianOptionEngineBuilder> asianOptionBuilder =
+            boost::dynamic_pointer_cast<AsianOptionEngineBuilder>(builder);
+
+        asian->setPricingEngine(
+            asianOptionBuilder->engine(assetName_, ccy, expiryDate_, strike_));
+
+        configuration = asianOptionBuilder->configuration(MarketContext::pricing);
+    } else {
+        DLOG("No engine attached for option on trade " << id() << " with expiry date " << io::iso_date(expiryDate_)
+                                                       << " because it is expired.");
+    }
+
+    Position::Type positionType = parsePositionType(option_.longShort());
+    Real bsInd = (positionType == QuantLib::Position::Long ? 1.0 : -1.0);
+    Real mult = quantity_ * bsInd;
+
+    // If premium data is provided
+    // 1) build the fee trade and pass it to the instrument wrapper for pricing
+    // 2) add fee payment as additional trade leg for cash flow reporting
+    std::vector<boost::shared_ptr<Instrument>> additionalInstruments;
+    std::vector<Real> additionalMultipliers;
+    if (option_.premiumPayDate() != "" && option_.premiumCcy() != "") {
+        Real premiumAmount = -bsInd * option_.premium(); // pay if long, receive if short
+        Currency premiumCurrency = parseCurrency(option_.premiumCcy());
+        Date premiumDate = parseDate(option_.premiumPayDate());
+        addPayment(additionalInstruments, additionalMultipliers, premiumDate, premiumAmount, premiumCurrency, ccy,
+                   engineFactory, configuration);
+        DLOG("Option premium added for asian option " << id());
+    }
+
+    // TODO: Use something like EuropeanOptionWrapper instead? After all, an asian option is not
+    // a vanilla instrument. However, the available European-/AmericanOptionWrapper is not directly
+    // applicable as it calls for both an instrument and an underlying instrument.
+    // Given how the asians are priced, though, we still manage fine using the VanillaInstrument wrapper
+    // for the time being.
+    instrument_ = boost::shared_ptr<InstrumentWrapper>(
+        new VanillaInstrument(asian, mult, additionalInstruments, additionalMultipliers));
+    //instrument_ = boost::shared_ptr<InstrumentWrapper>(
+    //    boost::make_shared<EuropeanOptionWrapper>(...));
+
+    npvCurrency_ = currency_;
+
+    // Notional - we really need todays spot to get the correct notional.
+    // But rather than having it move around we use strike * quantity
+    notional_ = strike_ * quantity_;
+    notionalCurrency_ = currency_;
+}
+
+void AsianOptionTrade::fromXML(XMLNode* node) { Trade::fromXML(node); }
+
+XMLNode* AsianOptionTrade::toXML(XMLDocument& doc) {
+    XMLNode* node = Trade::toXML(doc);
+    return node;
+}
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/asianoption.cpp
+++ b/OREData/ored/portfolio/asianoption.cpp
@@ -160,7 +160,7 @@ void AsianOptionTrade::build(const boost::shared_ptr<EngineFactory>& engineFacto
             boost::dynamic_pointer_cast<AsianOptionEngineBuilder>(builder);
 
         asian->setPricingEngine(
-            asianOptionBuilder->engine(assetName_, ccy, expiryDate_, strike_));
+            asianOptionBuilder->engine(assetName_, ccy, expiryDate_));
 
         configuration = asianOptionBuilder->configuration(MarketContext::pricing);
     } else {

--- a/OREData/ored/portfolio/asianoption.hpp
+++ b/OREData/ored/portfolio/asianoption.hpp
@@ -1,0 +1,86 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/asianoption.hpp
+    \brief Asian Option data model
+    \ingroup tradedata
+*/
+
+#pragma once
+
+#include <ored/portfolio/trade.hpp>
+#include <ored/portfolio/optiondata.hpp>
+#include <ored/utilities/parsers.hpp>
+#include <ql/instruments/averagetype.hpp>
+
+namespace ore {
+namespace data {
+using std::string;
+
+//! Serializable Asian Option
+/*!
+  \ingroup tradedata
+*/
+class AsianOptionTrade : public Trade {
+public:
+    //! Build QuantLib/QuantExt instrument, link pricing engine
+    void build(const boost::shared_ptr<EngineFactory>&) override;
+
+    //! \name Inspectors
+    //@{
+    const OptionData& option() const { return option_; }
+    const string& asset() const { return assetName_; }
+    const string& currency() const { return currency_; }
+    double strike() const { return strike_; }
+    double quantity() const { return quantity_; }
+
+    //! \name Serialisation
+    //@{
+    virtual void fromXML(XMLNode* node) override;
+    virtual XMLNode* toXML(XMLDocument& doc) override;
+    //@}
+
+protected:
+    AsianOptionTrade(AssetClass assetClassUnderlying)
+        : Trade("AsianOption"), assetClassUnderlying_(assetClassUnderlying), strike_(0), quantity_(0) {}
+    AsianOptionTrade(const Envelope& env, AssetClass assetClassUnderlying, OptionData option, string assetName,
+                     string currency, double strike, double quantity,
+                     const boost::shared_ptr<QuantLib::Index>& index = nullptr, const std::string& indexName = "")
+        : Trade("AsianOption", env), assetClassUnderlying_(assetClassUnderlying), option_(option),
+          assetName_(assetName), currency_(currency), strike_(strike), quantity_(quantity), index_(index),
+          indexName_(indexName) {}
+
+    AssetClass assetClassUnderlying_;
+    OptionData option_;
+    string assetName_;
+    string currency_;
+    double strike_;
+    double quantity_;
+
+    //! An index is needed if the option is to be automatically exercised on expiry.
+    boost::shared_ptr<QuantLib::Index> index_;
+
+    //! Hold the external index name if needed e.g. in the case of an FX index.
+    std::string indexName_;
+
+    //! Store the option expiry date.
+    QuantLib::Date expiryDate_;
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/asianoption.hpp
+++ b/OREData/ored/portfolio/asianoption.hpp
@@ -23,8 +23,9 @@
 
 #pragma once
 
-#include <ored/portfolio/trade.hpp>
+#include <ored/portfolio/optionasiandata.hpp>
 #include <ored/portfolio/optiondata.hpp>
+#include <ored/portfolio/trade.hpp>
 #include <ored/utilities/parsers.hpp>
 #include <ql/instruments/averagetype.hpp>
 
@@ -44,6 +45,8 @@ public:
     //! \name Inspectors
     //@{
     const OptionData& option() const { return option_; }
+    const OptionAsianData& asianData() const { return asianData_; }
+    const ScheduleData& scheduleData() const { return scheduleData_; }
     const string& asset() const { return assetName_; }
     const string& currency() const { return currency_; }
     double strike() const { return strike_; }
@@ -58,15 +61,17 @@ public:
 protected:
     AsianOptionTrade(AssetClass assetClassUnderlying)
         : Trade("AsianOption"), assetClassUnderlying_(assetClassUnderlying), strike_(0), quantity_(0) {}
-    AsianOptionTrade(const Envelope& env, AssetClass assetClassUnderlying, OptionData option, string assetName,
-                     string currency, double strike, double quantity,
+    AsianOptionTrade(const Envelope& env, AssetClass assetClassUnderlying, OptionData option, OptionAsianData asianData,
+                     ScheduleData scheduleData, string assetName, string currency, double strike, double quantity,
                      const boost::shared_ptr<QuantLib::Index>& index = nullptr, const std::string& indexName = "")
         : Trade("AsianOption", env), assetClassUnderlying_(assetClassUnderlying), option_(option),
-          assetName_(assetName), currency_(currency), strike_(strike), quantity_(quantity), index_(index),
-          indexName_(indexName) {}
+          asianData_(asianData), scheduleData_(scheduleData), assetName_(assetName), currency_(currency),
+          strike_(strike), quantity_(quantity), index_(index), indexName_(indexName) {}
 
     AssetClass assetClassUnderlying_;
     OptionData option_;
+    OptionAsianData asianData_;
+    ScheduleData scheduleData_;
     string assetName_;
     string currency_;
     double strike_;

--- a/OREData/ored/portfolio/builders/asianoption.hpp
+++ b/OREData/ored/portfolio/builders/asianoption.hpp
@@ -63,6 +63,9 @@ public:
                                            const Date&>::engine(ccy1.code(), ccy2, assetClass_, expiryDate);
     }
 
+    //! This is used in building the option to select between Discrete- and ContinuousAveragingAsianOption
+    virtual std::string processType() { return ""; }
+
 protected:
     virtual string keyImpl(const string& assetName, const Currency& ccy, const AssetClass& assetClassUnderlying,
                            const Date& expiryDate) override {
@@ -83,6 +86,8 @@ public:
     EuropeanAsianOptionMCDAAPEngineBuilder(const string& model, const set<string>& tradeTypes,
                                            const AssetClass& assetClass, const Date& expiryDate)
         : AsianOptionEngineBuilder(model, "MCDiscreteArithmeticAPEngine", tradeTypes, assetClass, expiryDate) {}
+
+    std::string processType() override { return "Discrete"; }
 
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
@@ -126,6 +131,8 @@ public:
                                            const AssetClass& assetClass, const Date& expiryDate)
         : AsianOptionEngineBuilder(model, "MCDiscreteArithmeticASEngine", tradeTypes, assetClass, expiryDate) {}
 
+    std::string processType() override { return "Discrete"; }
+
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
                                                         const AssetClass& assetClassUnderlying,
@@ -166,6 +173,8 @@ public:
                                            const AssetClass& assetClass, const Date& expiryDate)
         : AsianOptionEngineBuilder(model, "MCDiscreteGeometricAPEngine", tradeTypes, assetClass, expiryDate) {}
 
+    std::string processType() override { return "Discrete"; }
+
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
                                                         const AssetClass& assetClassUnderlying,
@@ -205,6 +214,8 @@ public:
                                           const AssetClass& assetClass)
         : AsianOptionEngineBuilder(model, "AnalyticDiscreteGeometricAPEngine", tradeTypes, assetClass, Date()) {}
 
+    std::string processType() override { return "Discrete"; }
+
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
                                                         const AssetClass& assetClassUnderlying,
@@ -226,6 +237,8 @@ public:
                                           const AssetClass& assetClass)
         : AsianOptionEngineBuilder(model, "AnalyticDiscreteGeometricASEngine", tradeTypes, assetClass, Date()) {}
 
+    std::string processType() override { return "Discrete"; }
+
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
                                                         const AssetClass& assetClassUnderlying,
@@ -239,6 +252,8 @@ protected:
 //! Continuous Analytic Engine Builder for European Asian Geometric Average Price Options
 /*! Pricing engines are cached by asset/currency
 
+    Note that this engine disregards fixing dates, i.e. it utilizes continuous averaging and is mainly for testing.
+
     \ingroup builders
  */
 class EuropeanAsianOptionACGAPEngineBuilder : public AsianOptionEngineBuilder {
@@ -246,6 +261,8 @@ public:
     EuropeanAsianOptionACGAPEngineBuilder(const string& model, const set<string>& tradeTypes,
                                           const AssetClass& assetClass)
         : AsianOptionEngineBuilder(model, "AnalyticContinuousGeometricAPEngine", tradeTypes, assetClass, Date()) {}
+
+    std::string processType() override { return "Continuous"; }
 
 protected:
     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,

--- a/OREData/ored/portfolio/builders/asianoption.hpp
+++ b/OREData/ored/portfolio/builders/asianoption.hpp
@@ -1,0 +1,326 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/builders/asianoption.hpp
+    \brief Abstract engine builders for European Asian Options
+    \ingroup builders
+*/
+
+#pragma once
+
+#include <ored/portfolio/builders/vanillaoption.hpp>
+#include <boost/make_shared.hpp>
+#include <ored/portfolio/builders/cachingenginebuilder.hpp>
+#include <ored/utilities/log.hpp>
+#include <ored/utilities/to_string.hpp>
+#include <ored/utilities/parsers.hpp>
+#include <ored/utilities/indexparser.hpp>
+#include <ql/pricingengines/asian/analytic_cont_geom_av_price.hpp>
+#include <ql/pricingengines/asian/analytic_discr_geom_av_price.hpp>
+#include <ql/pricingengines/asian/analytic_discr_geom_av_strike.hpp>
+#include <ql/pricingengines/asian/mc_discr_arith_av_price.hpp>
+#include <ql/pricingengines/asian/mc_discr_arith_av_strike.hpp>
+#include <ql/utilities/null.hpp>
+
+namespace ore {
+namespace data {
+
+//! Abstract Engine Builder for Asian Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where 
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+    
+    \ingroup builders
+ */
+class AsianOptionEngineBuilder : public CachingOptionEngineBuilder<string, const string&, const Currency&,
+                                                                   const AssetClass&, const Date&, const double> {
+public:
+    AsianOptionEngineBuilder(const string& model, const string& engine, const set<string>& tradeTypes,
+                             const AssetClass& assetClass, const Date& expiryDate, const double strike)
+        : CachingOptionEngineBuilder(model, engine, tradeTypes, assetClass), expiryDate_(expiryDate), strike_(strike) {}
+
+    boost::shared_ptr<PricingEngine> engine(const string& assetName, const Currency& ccy, const Date& expiryDate,
+                                            const double strike) {
+        return CachingPricingEngineBuilder<string, const string&, const Currency&, const AssetClass&, const Date&,
+                                           const double>::engine(assetName, ccy, assetClass_, expiryDate, strike);
+    }
+
+    boost::shared_ptr<PricingEngine> engine(const Currency& ccy1, const Currency& ccy2, const Date& expiryDate,
+                                            const double strike) {
+        return CachingPricingEngineBuilder<string, const string&, const Currency&, const AssetClass&, const Date&,
+                                           const double>::engine(ccy1.code(), ccy2, assetClass_, expiryDate, strike);
+    }
+
+protected:
+    virtual string keyImpl(const string& assetName, const Currency& ccy, const AssetClass& assetClassUnderlying,
+                           const Date& expiryDate, const double strike) override {
+        return assetName + "/" + ccy.code() + "/" + to_string(expiryDate) + "/" + to_string(strike);
+    }
+
+    boost::shared_ptr<GeneralizedBlackScholesProcess>
+    getConstBlackScholesProcess(const string& assetName, const Currency& ccy, const AssetClass& assetClassUnderlying,
+                                const Date& expiryDate, const double strike) {
+        // Probably should change so that expiryDate_ and strike_ are populated and used instead as parameters for
+        // function call and in blackVol()-call.
+
+        string config = configuration(ore::data::MarketContext::pricing);
+
+        if (assetClassUnderlying == AssetClass::EQ) {
+            Handle<BlackVolTermStructure> vol = market_->equityVol(assetName, config);
+            Volatility constVol = vol->blackVol(expiryDate, strike, true);
+            vol = Handle<BlackVolTermStructure>(boost::make_shared<BlackConstantVol>(
+                vol->referenceDate(), vol->calendar(), constVol, vol->dayCounter()));
+
+            DLOG("Configured Black const vol = " << constVol << " for asset name = " << assetName
+                                                << " with expiry date = " << expiryDate << " and strike = " << strike);
+            return boost::make_shared<GeneralizedBlackScholesProcess>(
+                market_->equitySpot(assetName, config), market_->equityDividendCurve(assetName, config),
+                market_->equityForecastCurve(assetName, config), vol);
+        } else if (assetClassUnderlying == AssetClass::FX) {
+            const string& ccyPairCode = assetName + ccy.code();
+            Handle<BlackVolTermStructure> vol = market_->fxVol(ccyPairCode, config);
+            Volatility constVol = vol->blackVol(expiryDate, strike, true);
+            vol = Handle<BlackVolTermStructure>(boost::make_shared<BlackConstantVol>(
+                vol->referenceDate(), vol->calendar(), constVol, vol->dayCounter()));
+
+            return boost::make_shared<GeneralizedBlackScholesProcess>(market_->fxSpot(ccyPairCode, config),
+                                                                      market_->discountCurve(assetName, config),
+                                                                      market_->discountCurve(ccy.code(), config), vol);
+        } else if (assetClassUnderlying == AssetClass::COM) {
+            Handle<BlackVolTermStructure> vol = market_->commodityVolatility(assetName, config);
+
+            Date asof = vol->referenceDate();
+            DayCounter volDc = vol->dayCounter();
+            std::vector<Date> dates(expiryDate - asof);
+            std::vector<Volatility> volatilities(expiryDate - asof);
+
+            /*size_t index = 0;
+            for (Date d = asof + 1; d <= expiryDate; ++d) {
+                dates[index] = d;
+                volatilities[index] = vol->blackVol(dates[index], strike, true);
+                DLOG("Configured Black vol = " << volatilities[index] << " at date = " << d
+                                               << " for asset name = " << assetName
+                                               << " with expiry date = " << expiryDate << " and strike = " << strike);
+                ++index;
+            }
+            vol = Handle<BlackVolTermStructure>(
+                boost::make_shared<BlackVarianceCurve>(asof, dates, volatilities, volDc, false));
+            */
+            
+            Volatility constVol = vol->blackVol(expiryDate, strike, true);
+            vol = Handle<BlackVolTermStructure>(boost::make_shared<BlackConstantVol>(
+                vol->referenceDate(), vol->calendar(), constVol, vol->dayCounter()));
+
+            DLOG("Configured Black const vol = " << constVol << " for asset name = " << assetName
+                                                 << " with expiry date = " << expiryDate << " and strike = " << strike);
+            
+
+            // Create the commodity convenience yield curve for the process
+            Handle<QuantExt::PriceTermStructure> priceCurve = market_->commodityPriceCurve(assetName, config);
+            Handle<Quote> commoditySpot(boost::make_shared<QuantExt::DerivedPriceQuote>(priceCurve));
+            Handle<YieldTermStructure> discount = market_->discountCurve(ccy.code(), config);
+            Handle<YieldTermStructure> yield(
+                boost::make_shared<QuantExt::PriceTermStructureAdapter>(*priceCurve, *discount));
+            yield->enableExtrapolation();
+
+            return boost::make_shared<GeneralizedBlackScholesProcess>(commoditySpot, yield, discount, vol);
+        } else {
+            QL_FAIL("Asset class of " << (int)assetClassUnderlying << " not recognized.");
+        }
+    }
+
+    Date expiryDate_;
+    double strike_;
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Arithmetic Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionMCDAAPEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionMCDAAPEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                           const AssetClass& assetClass, const Date& expiryDate, const double strike)
+        : AsianOptionEngineBuilder(model, "MCDiscreteArithmeticAPEngine", tradeTypes, assetClass, expiryDate, strike) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        bool brownianBridge = ore::data::parseBool(engineParameter("BrownianBridge", "", false, "true"));
+        bool antitheticVariate = ore::data::parseBool(engineParameter("AntitheticVariate", "", false, "true"));
+        bool controlVariate = ore::data::parseBool(engineParameter("ControlVariate", "", false, "true"));
+        Size requiredSamples = ore::data::parseInteger(engineParameter("RequiredSamples", "", false, "0"));
+        Real requiredTolerance = ore::data::parseReal(engineParameter("RequiredTolerance", "", false, "0"));
+        Size maxSamples = ore::data::parseInteger(engineParameter("MaxSamples", "", false, "0"));
+        BigNatural seed = ore::data::parseInteger(engineParameter("Seed", "", false, "123456"));
+
+        // Check if values defaulted to 0, if so replace by Null<T>().
+        if (requiredSamples == 0)
+            requiredSamples = Null<Size>();
+        if (requiredTolerance == 0)
+            requiredTolerance = Null<Real>();
+        if (maxSamples == 0)
+            maxSamples = Null<Size>();
+        QL_REQUIRE(requiredSamples != QuantLib::Null<Size>() || requiredTolerance != QuantLib::Null<Real>(),
+                   "RequiredSamples or RequiredTolerance must be set for engine MCDiscreteArithmeticAPEngine.");
+
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getConstBlackScholesProcess(assetName, ccy, assetClassUnderlying, expiryDate, strike);
+        return boost::make_shared<MCDiscreteArithmeticAPEngine<LowDiscrepancy>>(gbsp, brownianBridge, antitheticVariate,
+                                                                  controlVariate, requiredSamples, requiredTolerance,
+                                                                  maxSamples, seed);
+    }
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Arithmetic Average Strike Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionMCDAASEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionMCDAASEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                           const AssetClass& assetClass, const Date& expiryDate, const double strike)
+        : AsianOptionEngineBuilder(model, "MCDiscreteArithmeticASEngine", tradeTypes, assetClass, expiryDate, strike) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        bool brownianBridge = ore::data::parseBool(engineParameter("BrownianBridge", "", false, "true"));
+        bool antitheticVariate = ore::data::parseBool(engineParameter("AntitheticVariate", "", false, "true"));
+        Size requiredSamples = ore::data::parseInteger(engineParameter("RequiredSamples"));
+        Real requiredTolerance = ore::data::parseReal(engineParameter("RequiredTolerance"));
+        Size maxSamples = ore::data::parseInteger(engineParameter("MaxSamples"));
+        BigNatural seed = ore::data::parseInteger(engineParameter("Seed", "", false, "123456"));
+
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getConstBlackScholesProcess(assetName, ccy, assetClassUnderlying, expiryDate, strike);
+        return boost::make_shared<MCDiscreteArithmeticASEngine<>>(gbsp, brownianBridge, antitheticVariate,
+                                                                  requiredSamples, requiredTolerance, maxSamples, seed);
+    }
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionMCDGAPEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionMCDGAPEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                           const AssetClass& assetClass, const Date& expiryDate, const double strike)
+        : AsianOptionEngineBuilder(model, "MCDiscreteGeometricAPEngine", tradeTypes, assetClass, expiryDate, strike) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        bool brownianBridge = ore::data::parseBool(engineParameter("BrownianBridge", "", false, "true"));
+        bool antitheticVariate = ore::data::parseBool(engineParameter("AntitheticVariate", "", false, "true"));
+        Size requiredSamples = ore::data::parseInteger(engineParameter("RequiredSamples", "", false, "0"));
+        Real requiredTolerance = ore::data::parseReal(engineParameter("RequiredTolerance", "", false, "0"));
+        Size maxSamples = ore::data::parseInteger(engineParameter("MaxSamples", "", false, "0"));
+        BigNatural seed = ore::data::parseInteger(engineParameter("Seed", "", false, "123456"));
+
+        // Check if values defaulted to 0, if so replace by Null<T>().
+        if (requiredSamples == 0)
+            requiredSamples = Null<Size>();
+        if (requiredTolerance == 0)
+            requiredTolerance = Null<Real>();
+        if (maxSamples == 0)
+            maxSamples = Null<Size>();
+        QL_REQUIRE(requiredSamples != QuantLib::Null<Size>() || requiredTolerance != QuantLib::Null<Real>(),
+                   "RequiredSamples or RequiredTolerance must be set for engine MCDiscreteArithmeticAPEngine.");
+
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getConstBlackScholesProcess(assetName, ccy, assetClassUnderlying, expiryDate, strike);
+        return boost::make_shared<MCDiscreteGeometricAPEngine<>>(gbsp, brownianBridge, antitheticVariate,
+                                                                 requiredSamples, requiredTolerance, maxSamples, seed);
+    }
+};
+
+//! Discrete Analytic Engine Builder for European Asian Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionADGAPEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionADGAPEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                          const AssetClass& assetClass)
+        : AsianOptionEngineBuilder(model, "AnalyticDiscreteGeometricAPEngine", tradeTypes, assetClass, Date(), 0) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getBlackScholesProcess(assetName, ccy, assetClassUnderlying);
+        return boost::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(gbsp);
+    }
+};
+
+//! Discrete Analytic Engine Builder for European Asian Geometric Average Strike Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionADGASEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionADGASEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                          const AssetClass& assetClass)
+        : AsianOptionEngineBuilder(model, "AnalyticDiscreteGeometricASEngine", tradeTypes, assetClass, Date(), 0) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getBlackScholesProcess(assetName, ccy, assetClassUnderlying);
+        return boost::make_shared<AnalyticDiscreteGeometricAverageStrikeAsianEngine>(gbsp);
+    }
+};
+
+//! Continuous Analytic Engine Builder for European Asian Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EuropeanAsianOptionACGAPEngineBuilder : public AsianOptionEngineBuilder {
+public:
+    EuropeanAsianOptionACGAPEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                          const AssetClass& assetClass)
+        : AsianOptionEngineBuilder(model, "AnalyticContinuousGeometricAPEngine", tradeTypes, assetClass, Date(), 0) {}
+
+protected:
+    virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                        const AssetClass& assetClassUnderlying, const Date& expiryDate,
+                                                        const double strike) override {
+        boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+            getBlackScholesProcess(assetName, ccy, assetClassUnderlying);
+        return boost::make_shared<AnalyticContinuousGeometricAveragePriceAsianEngine>(gbsp);
+    }
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/builders/asianoption.hpp
+++ b/OREData/ored/portfolio/builders/asianoption.hpp
@@ -207,15 +207,25 @@ protected:
                                                         const double strike) override {
         bool brownianBridge = ore::data::parseBool(engineParameter("BrownianBridge", "", false, "true"));
         bool antitheticVariate = ore::data::parseBool(engineParameter("AntitheticVariate", "", false, "true"));
-        Size requiredSamples = ore::data::parseInteger(engineParameter("RequiredSamples"));
-        Real requiredTolerance = ore::data::parseReal(engineParameter("RequiredTolerance"));
-        Size maxSamples = ore::data::parseInteger(engineParameter("MaxSamples"));
+        Size requiredSamples = ore::data::parseInteger(engineParameter("RequiredSamples", "", false, "0"));
+        Real requiredTolerance = ore::data::parseReal(engineParameter("RequiredTolerance", "", false, "0"));
+        Size maxSamples = ore::data::parseInteger(engineParameter("MaxSamples", "", false, "0"));
         BigNatural seed = ore::data::parseInteger(engineParameter("Seed", "", false, "123456"));
+
+        // Check if values defaulted to 0, if so replace by Null<T>().
+        if (requiredSamples == 0)
+            requiredSamples = Null<Size>();
+        if (requiredTolerance == 0)
+            requiredTolerance = Null<Real>();
+        if (maxSamples == 0)
+            maxSamples = Null<Size>();
+        QL_REQUIRE(requiredSamples != QuantLib::Null<Size>() || requiredTolerance != QuantLib::Null<Real>(),
+                   "RequiredSamples or RequiredTolerance must be set for engine MCDiscreteArithmeticASEngine.");
 
         boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
             getConstBlackScholesProcess(assetName, ccy, assetClassUnderlying, expiryDate, strike);
-        return boost::make_shared<MCDiscreteArithmeticASEngine<>>(gbsp, brownianBridge, antitheticVariate,
-                                                                  requiredSamples, requiredTolerance, maxSamples, seed);
+        return boost::make_shared<MCDiscreteArithmeticASEngine<LowDiscrepancy>>(
+            gbsp, brownianBridge, antitheticVariate, requiredSamples, requiredTolerance, maxSamples, seed);
     }
 };
 
@@ -254,8 +264,8 @@ protected:
 
         boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
             getConstBlackScholesProcess(assetName, ccy, assetClassUnderlying, expiryDate, strike);
-        return boost::make_shared<MCDiscreteGeometricAPEngine<>>(gbsp, brownianBridge, antitheticVariate,
-                                                                 requiredSamples, requiredTolerance, maxSamples, seed);
+        return boost::make_shared<MCDiscreteGeometricAPEngine<LowDiscrepancy>>(
+            gbsp, brownianBridge, antitheticVariate, requiredSamples, requiredTolerance, maxSamples, seed);
     }
 };
 

--- a/OREData/ored/portfolio/builders/commodityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/commodityasianoption.hpp
@@ -29,8 +29,8 @@ namespace ore {
 namespace data {
 
 //! Discrete Monte Carlo Engine Builder for European Asian Commodity Arithmetic Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -38,12 +38,12 @@ class CommodityEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOpti
 public:
     CommodityEuropeanAsianOptionMCDAAPEngineBuilder()
         : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticPrice"},
-                                                 AssetClass::COM, expiryDate_, strike_) {}
+                                                 AssetClass::COM, expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Commodity Arithmetic Average Strike Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -51,20 +51,20 @@ class CommodityEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOpti
 public:
     CommodityEuropeanAsianOptionMCDAASEngineBuilder()
         : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticStrike"},
-                                                 AssetClass::COM, expiryDate_, strike_) {}
+                                                 AssetClass::COM, expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Commodity Geometric Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
 class CommodityEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
 public:
     CommodityEuropeanAsianOptionMCDGAPEngineBuilder()
-        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticPrice"},
-                                                 AssetClass::COM, expiryDate_, strike_) {}
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionGeometricPrice"},
+                                                 AssetClass::COM, expiryDate_) {}
 };
 
 //! Discrete Analytic Engine Builder for European Asian Commodity Geometric Average Price Options

--- a/OREData/ored/portfolio/builders/commodityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/commodityasianoption.hpp
@@ -1,0 +1,107 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/builders/commodityasianoption.hpp
+    \brief Engine builder for commodity Asian options
+    \ingroup builders
+*/
+
+#pragma once
+
+#include <ored/portfolio/builders/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Discrete Monte Carlo Engine Builder for European Asian Commodity Arithmetic Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionMCDAAPEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionMCDAAPEngineBuilder()
+        : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticPrice"},
+                                                 AssetClass::COM, expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Commodity Arithmetic Average Strike Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionMCDAASEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionMCDAASEngineBuilder()
+        : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticStrike"},
+                                                 AssetClass::COM, expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Commodity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionMCDGAPEngineBuilder()
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticPrice"},
+                                                 AssetClass::COM, expiryDate_, strike_) {}
+};
+
+//! Discrete Analytic Engine Builder for European Asian Commodity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionADGAPEngineBuilder : public EuropeanAsianOptionADGAPEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionADGAPEngineBuilder()
+        : EuropeanAsianOptionADGAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionGeometricPrice"},
+                                                AssetClass::COM) {}
+};
+
+//! Discrete Analytic Engine Builder for European Asian Commodity Geometric Average Strike Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionADGASEngineBuilder : public EuropeanAsianOptionADGASEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionADGASEngineBuilder()
+        : EuropeanAsianOptionADGASEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionGeometricStrike"},
+                                                AssetClass::COM) {}
+};
+
+//! Continuous Analytic Engine Builder for European Asian Commodity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class CommodityEuropeanAsianOptionACGAPEngineBuilder : public EuropeanAsianOptionACGAPEngineBuilder {
+public:
+    CommodityEuropeanAsianOptionACGAPEngineBuilder()
+        : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionGeometricPrice"},
+                                                AssetClass::COM) {}
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/builders/equityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/equityasianoption.hpp
@@ -1,0 +1,107 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/builders/equityasianoption.hpp
+    \brief Engine builder for equity Asian options
+    \ingroup builders
+*/
+
+#pragma once
+
+#include <ored/portfolio/builders/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Discrete Monte Carlo Engine Builder for European Asian Equity Arithmetic Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionMCDAAPEngineBuilder {
+public:
+    EquityEuropeanAsianOptionMCDAAPEngineBuilder()
+        : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticPrice"},
+                                                 AssetClass::EQ, expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Equity Arithmetic Average Strike Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionMCDAASEngineBuilder {
+public:
+    EquityEuropeanAsianOptionMCDAASEngineBuilder()
+        : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticStrike"},
+                                                 AssetClass::EQ, expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Equity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
+public:
+    EquityEuropeanAsianOptionMCDGAPEngineBuilder()
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticPrice"},
+                                                 AssetClass::EQ, expiryDate_, strike_) {}
+};
+
+//! Discrete Analytic Engine Builder for European Asian Equity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionADGAPEngineBuilder : public EuropeanAsianOptionADGAPEngineBuilder {
+public:
+    EquityEuropeanAsianOptionADGAPEngineBuilder()
+        : EuropeanAsianOptionADGAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionGeometricPrice"},
+                                                AssetClass::EQ) {}
+};
+
+//! Discrete Analytic Engine Builder for European Asian Equity Geometric Average Strike Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionADGASEngineBuilder : public EuropeanAsianOptionADGASEngineBuilder {
+public:
+    EquityEuropeanAsianOptionADGASEngineBuilder()
+        : EuropeanAsianOptionADGASEngineBuilder("BlackScholesMerton", {"EquityAsianOptionGeometricStrike"},
+                                                AssetClass::EQ) {}
+};
+
+//! Continuous Analytic Engine Builder for European Asian Equity Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class EquityEuropeanAsianOptionACGAPEngineBuilder : public EuropeanAsianOptionACGAPEngineBuilder {
+public:
+    EquityEuropeanAsianOptionACGAPEngineBuilder()
+        : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionGeometricPrice"},
+                                                AssetClass::EQ) {}
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/builders/equityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/equityasianoption.hpp
@@ -29,8 +29,8 @@ namespace ore {
 namespace data {
 
 //! Discrete Monte Carlo Engine Builder for European Asian Equity Arithmetic Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -38,12 +38,12 @@ class EquityEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionM
 public:
     EquityEuropeanAsianOptionMCDAAPEngineBuilder()
         : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticPrice"},
-                                                 AssetClass::EQ, expiryDate_, strike_) {}
+                                                 AssetClass::EQ, expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Equity Arithmetic Average Strike Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -51,20 +51,20 @@ class EquityEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionM
 public:
     EquityEuropeanAsianOptionMCDAASEngineBuilder()
         : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticStrike"},
-                                                 AssetClass::EQ, expiryDate_, strike_) {}
+                                                 AssetClass::EQ, expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Equity Geometric Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
 class EquityEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
 public:
     EquityEuropeanAsianOptionMCDGAPEngineBuilder()
-        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticPrice"},
-                                                 AssetClass::EQ, expiryDate_, strike_) {}
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"EquityAsianOptionGeometricPrice"},
+                                                 AssetClass::EQ, expiryDate_) {}
 };
 
 //! Discrete Analytic Engine Builder for European Asian Equity Geometric Average Price Options

--- a/OREData/ored/portfolio/builders/fxasianoption.hpp
+++ b/OREData/ored/portfolio/builders/fxasianoption.hpp
@@ -29,8 +29,8 @@ namespace ore {
 namespace data {
 
 //! Discrete Monte Carlo Engine Builder for European Asian Fx Arithmetic Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -38,12 +38,12 @@ class FxEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionMCDAA
 public:
     FxEuropeanAsianOptionMCDAAPEngineBuilder()
         : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
-                                                 expiryDate_, strike_) {}
+                                                 expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Fx Arithmetic Average Strike Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
@@ -51,20 +51,20 @@ class FxEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionMCDAA
 public:
     FxEuropeanAsianOptionMCDAASEngineBuilder()
         : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticStrike"},
-                                                 AssetClass::FX, expiryDate_, strike_) {}
+                                                 AssetClass::FX, expiryDate_) {}
 };
 
 //! Discrete Monte Carlo Engine Builder for European Asian Fx Geometric Average Price Options
-/*! Pricing engines are cached by asset/currency/expiry/strike, where
-    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+/*! Pricing engines are cached by asset/currency/expiry, where
+    expiry is null (Date()) if irrelevant.
 
     \ingroup builders
  */
 class FxEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
 public:
     FxEuropeanAsianOptionMCDGAPEngineBuilder()
-        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
-                                                 expiryDate_, strike_) {}
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX,
+                                                 expiryDate_) {}
 };
 
 //! Discrete Analytic Engine Builder for European Asian Fx Geometric Average Price Options
@@ -99,8 +99,8 @@ public:
 class FxEuropeanAsianOptionACGAPEngineBuilder : public EuropeanAsianOptionACGAPEngineBuilder {
 public:
     FxEuropeanAsianOptionACGAPEngineBuilder()
-        : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"},
-                                                AssetClass::FX) {}
+        : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
+    }
 };
 
 } // namespace data

--- a/OREData/ored/portfolio/builders/fxasianoption.hpp
+++ b/OREData/ored/portfolio/builders/fxasianoption.hpp
@@ -1,0 +1,107 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/builders/fxasianoption.hpp
+    \brief Engine builder for fx Asian options
+    \ingroup builders
+*/
+
+#pragma once
+
+#include <ored/portfolio/builders/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Discrete Monte Carlo Engine Builder for European Asian Fx Arithmetic Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionMCDAAPEngineBuilder {
+public:
+    FxEuropeanAsianOptionMCDAAPEngineBuilder()
+        : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
+                                                 expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Fx Arithmetic Average Strike Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionMCDAASEngineBuilder {
+public:
+    FxEuropeanAsianOptionMCDAASEngineBuilder()
+        : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticStrike"},
+                                                 AssetClass::FX, expiryDate_, strike_) {}
+};
+
+//! Discrete Monte Carlo Engine Builder for European Asian Fx Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency/expiry/strike, where
+    expiry is null (Date()) if irrelevant and strike is 0 if irrelevant.
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
+public:
+    FxEuropeanAsianOptionMCDGAPEngineBuilder()
+        : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
+                                                 expiryDate_, strike_) {}
+};
+
+//! Discrete Analytic Engine Builder for European Asian Fx Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionADGAPEngineBuilder : public EuropeanAsianOptionADGAPEngineBuilder {
+public:
+    FxEuropeanAsianOptionADGAPEngineBuilder()
+        : EuropeanAsianOptionADGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
+    }
+};
+
+//! Discrete Analytic Engine Builder for European Asian Fx Geometric Average Strike Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionADGASEngineBuilder : public EuropeanAsianOptionADGASEngineBuilder {
+public:
+    FxEuropeanAsianOptionADGASEngineBuilder()
+        : EuropeanAsianOptionADGASEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricStrike"},
+                                                AssetClass::FX) {}
+};
+
+//! Continuous Analytic Engine Builder for European Asian Fx Geometric Average Price Options
+/*! Pricing engines are cached by asset/currency
+
+    \ingroup builders
+ */
+class FxEuropeanAsianOptionACGAPEngineBuilder : public EuropeanAsianOptionACGAPEngineBuilder {
+public:
+    FxEuropeanAsianOptionACGAPEngineBuilder()
+        : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"},
+                                                AssetClass::FX) {}
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/commodityasianoption.cpp
+++ b/OREData/ored/portfolio/commodityasianoption.cpp
@@ -1,0 +1,122 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <ored/portfolio/commodityasianoption.hpp>
+
+#include <boost/make_shared.hpp>
+
+#include <qle/indexes/commodityindex.hpp>
+#include <qle/termstructures/pricetermstructure.hpp>
+#include <ql/errors.hpp>
+
+#include <ored/portfolio/enginefactory.hpp>
+#include <ored/utilities/log.hpp>
+#include <ored/utilities/to_string.hpp>
+
+namespace ore {
+namespace data {
+
+void CommodityAsianOption::build(const boost::shared_ptr<EngineFactory>& engineFactory) {
+    // Checks
+    QL_REQUIRE(quantity_ > 0, "Commodity Asian option requires a positive quatity");
+    QL_REQUIRE(strike_ >= 0, "Commodity Asian option requires a strike >= 0");
+
+    // Get the price curve for the commodity.
+    const boost::shared_ptr<Market>& market = engineFactory->market();
+    Handle<QuantExt::PriceTermStructure> priceCurve =
+        market->commodityPriceCurve(assetName_, engineFactory->configuration(MarketContext::pricing));
+
+    // Populate the index_ in case the option is automatic exercise.
+    // Intentionally use null calendar because we will ask for index value on the expiry date without adjustment.
+    if (!isFuturePrice_ || *isFuturePrice_) {
+        // Assume future price if isFuturePrice_ is not explicitly set or if it is and true.
+
+        // If we are given an explicit future contract expiry date, use it, otherwise use option's expiry.
+        Date expiryDate;
+        if (futureExpiryDate_ != Date()) {
+            expiryDate = futureExpiryDate_;
+        } else {
+            // Get the expiry date of the option. This is the expiry date of the commodity future index.
+            const vector<string>& expiryDates = option_.exerciseDates();
+            QL_REQUIRE(expiryDates.size() == 1, "Expected exactly one expiry date for CommodityAsianOption but got "
+                                                    << expiryDates.size() << ".");
+            expiryDate = parseDate(expiryDates[0]);
+        }
+
+        index_ = boost::make_shared<QuantExt::CommodityFuturesIndex>(assetName_, expiryDate, NullCalendar(), priceCurve);
+    } else {
+        // If the underlying is a commodity spot, create a spot index.
+        index_ = boost::make_shared<QuantExt::CommoditySpotIndex>(assetName_, NullCalendar(), priceCurve);
+    }
+
+    AsianOptionTrade::build(engineFactory);
+}
+
+std::map<AssetClass, std::set<std::string>> CommodityAsianOption::underlyingIndices() const {
+    return {{AssetClass::COM, std::set<std::string>({assetName_})}};
+}
+
+void CommodityAsianOption::fromXML(XMLNode* node) {
+    Trade::fromXML(node);
+
+    XMLNode* commodityNode = XMLUtils::getChildNode(node, "CommodityAsianOptionData");
+    QL_REQUIRE(commodityNode, "A commodity Asian option needs a 'CommodityAsianOptionData' node");
+
+    option_.fromXML(XMLUtils::getChildNode(commodityNode, "OptionData"));
+    QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for CommodityAsianOption.");
+
+    assetName_ = XMLUtils::getChildValue(commodityNode, "Name", true);
+    currency_ = XMLUtils::getChildValue(commodityNode, "Currency", true);
+    // Require explicit Strike
+    strike_ = XMLUtils::getChildValueAsDouble(commodityNode, "Strike", true);
+    quantity_ = XMLUtils::getChildValueAsDouble(commodityNode, "Quantity", true);
+
+    isFuturePrice_ = boost::none;
+    if (XMLNode* n = XMLUtils::getChildNode(commodityNode, "IsFuturePrice"))
+        isFuturePrice_ = parseBool(XMLUtils::getNodeValue(n));
+
+    futureExpiryDate_ = Date();
+    if (XMLNode* n = XMLUtils::getChildNode(commodityNode, "FutureExpiryDate"))
+        futureExpiryDate_ = parseDate(XMLUtils::getNodeValue(n));
+}
+
+XMLNode* CommodityAsianOption::toXML(XMLDocument& doc) {
+    XMLNode* node = Trade::toXML(doc);
+
+    XMLNode* eqNode = doc.allocNode("CommodityAsianOptionData");
+    XMLUtils::appendNode(node, eqNode);
+
+    XMLUtils::appendNode(eqNode, option_.toXML(doc));
+
+    XMLUtils::addChild(doc, eqNode, "Name", assetName_);
+    XMLUtils::addChild(doc, eqNode, "Currency", currency_);
+    XMLUtils::addChild(doc, eqNode, "Strike", strike_);
+    XMLUtils::addChild(doc, eqNode, "Quantity", quantity_);
+
+    if (isFuturePrice_)
+        XMLUtils::addChild(doc, eqNode, "IsFuturePrice", *isFuturePrice_);
+
+    if (futureExpiryDate_ != Date())
+        XMLUtils::addChild(doc, eqNode, "FutureExpiryDate", to_string(futureExpiryDate_));
+
+    return node;
+}
+
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/commodityasianoption.cpp
+++ b/OREData/ored/portfolio/commodityasianoption.cpp
@@ -79,6 +79,11 @@ void CommodityAsianOption::fromXML(XMLNode* node) {
 
     option_.fromXML(XMLUtils::getChildNode(commodityNode, "OptionData"));
     QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for CommodityAsianOption.");
+    XMLNode* asianNode = XMLUtils::getChildNode(commodityNode, "AsianData");
+    asianData_.fromXML(asianNode);
+
+    XMLNode* scheduleDataNode = XMLUtils::getChildNode(commodityNode, "ScheduleData");
+    scheduleData_.fromXML(scheduleDataNode);
 
     assetName_ = XMLUtils::getChildValue(commodityNode, "Name", true);
     currency_ = XMLUtils::getChildValue(commodityNode, "Currency", true);
@@ -98,21 +103,23 @@ void CommodityAsianOption::fromXML(XMLNode* node) {
 XMLNode* CommodityAsianOption::toXML(XMLDocument& doc) {
     XMLNode* node = Trade::toXML(doc);
 
-    XMLNode* eqNode = doc.allocNode("CommodityAsianOptionData");
-    XMLUtils::appendNode(node, eqNode);
+    XMLNode* comNode = doc.allocNode("CommodityAsianOptionData");
+    XMLUtils::appendNode(node, comNode);
 
-    XMLUtils::appendNode(eqNode, option_.toXML(doc));
+    XMLUtils::appendNode(comNode, option_.toXML(doc));
+    XMLUtils::appendNode(comNode, asianData_.toXML(doc));
+    XMLUtils::appendNode(comNode, scheduleData_.toXML(doc));
 
-    XMLUtils::addChild(doc, eqNode, "Name", assetName_);
-    XMLUtils::addChild(doc, eqNode, "Currency", currency_);
-    XMLUtils::addChild(doc, eqNode, "Strike", strike_);
-    XMLUtils::addChild(doc, eqNode, "Quantity", quantity_);
+    XMLUtils::addChild(doc, comNode, "Name", assetName_);
+    XMLUtils::addChild(doc, comNode, "Currency", currency_);
+    XMLUtils::addChild(doc, comNode, "Strike", strike_);
+    XMLUtils::addChild(doc, comNode, "Quantity", quantity_);
 
     if (isFuturePrice_)
-        XMLUtils::addChild(doc, eqNode, "IsFuturePrice", *isFuturePrice_);
+        XMLUtils::addChild(doc, comNode, "IsFuturePrice", *isFuturePrice_);
 
     if (futureExpiryDate_ != Date())
-        XMLUtils::addChild(doc, eqNode, "FutureExpiryDate", to_string(futureExpiryDate_));
+        XMLUtils::addChild(doc, comNode, "FutureExpiryDate", to_string(futureExpiryDate_));
 
     return node;
 }

--- a/OREData/ored/portfolio/commodityasianoption.hpp
+++ b/OREData/ored/portfolio/commodityasianoption.hpp
@@ -1,0 +1,81 @@
+/*
+ Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/commodityasianoption.hpp
+    \brief Commodity Asian Option data model and serialization
+    \ingroup tradedata
+*/
+
+#pragma once
+
+#include <ored/portfolio/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Serializable Commodity Asian Option
+/*!
+  \ingroup tradedata
+*/
+class CommodityAsianOption : public AsianOptionTrade {
+public:
+    //! Default constructor
+    CommodityAsianOption() : AsianOptionTrade(AssetClass::COM) { tradeType_ = "CommodityAsianOption"; }
+    
+    //! Detailed constructor
+    CommodityAsianOption(const Envelope& env, const OptionData& optionData, const std::string& commodityName,
+                         const std::string& currency, QuantLib::Real strike, QuantLib::Real quantity,
+                         const boost::optional<bool>& isFuturePrice = boost::none,
+                         const QuantLib::Date& futureExpiryDate = QuantLib::Date())
+        : AsianOptionTrade(env, AssetClass::COM, optionData, commodityName, currency, strike, quantity),
+          isFuturePrice_(isFuturePrice), futureExpiryDate_(futureExpiryDate) {
+        tradeType_ = "CommodityAsianOption";
+    }
+
+    //! Build underlying instrument and link pricing engine
+    void build(const boost::shared_ptr<EngineFactory>&) override;
+
+    //! Add underlying Commodity names
+    std::map<AssetClass, std::set<std::string>> underlyingIndices() const override;
+
+    //! \name Inspectors
+    //@{
+    const boost::optional<bool>& isFuturePrice() const { return isFuturePrice_; }
+    const QuantLib::Date& futureExpiryDate() const { return futureExpiryDate_; }
+    //@}
+
+    //! \name Serialisation
+    //@{
+    virtual void fromXML(XMLNode* node) override;
+    virtual XMLNode* toXML(XMLDocument& doc) override;
+    //@}
+
+private:
+    /*! Indicates if the option underlying is a commodity future settlement price, \c true, or a spot price \c false.
+        If not explicitly set, it is assumed to be \c true.
+    */
+    boost::optional<bool> isFuturePrice_;
+
+    /*! An explicit expiry date for the underlying future contract. This can be used if the option trade references a
+        future contract settlement price and the option's expiry date does not match the future contract expiry date.
+    */
+    QuantLib::Date futureExpiryDate_;
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/commodityasianoption.hpp
+++ b/OREData/ored/portfolio/commodityasianoption.hpp
@@ -38,11 +38,13 @@ public:
     CommodityAsianOption() : AsianOptionTrade(AssetClass::COM) { tradeType_ = "CommodityAsianOption"; }
     
     //! Detailed constructor
-    CommodityAsianOption(const Envelope& env, const OptionData& optionData, const std::string& commodityName,
-                         const std::string& currency, QuantLib::Real strike, QuantLib::Real quantity,
+    CommodityAsianOption(const Envelope& env, const OptionData& optionData, const OptionAsianData& asianData,
+                         ScheduleData scheduleData, const std::string& commodityName, const std::string& currency,
+                         QuantLib::Real strike, QuantLib::Real quantity,
                          const boost::optional<bool>& isFuturePrice = boost::none,
                          const QuantLib::Date& futureExpiryDate = QuantLib::Date())
-        : AsianOptionTrade(env, AssetClass::COM, optionData, commodityName, currency, strike, quantity),
+        : AsianOptionTrade(env, AssetClass::COM, optionData, asianData, scheduleData, commodityName, currency, strike,
+                           quantity),
           isFuturePrice_(isFuturePrice), futureExpiryDate_(futureExpiryDate) {
         tradeType_ = "CommodityAsianOption";
     }

--- a/OREData/ored/portfolio/enginefactory.cpp
+++ b/OREData/ored/portfolio/enginefactory.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -26,13 +27,16 @@
 #include <ored/portfolio/builders/capflooredyoyleg.hpp>
 #include <ored/portfolio/builders/cms.hpp>
 #include <ored/portfolio/builders/cmsspread.hpp>
+#include <ored/portfolio/builders/commodityasianoption.hpp>
 #include <ored/portfolio/builders/commodityforward.hpp>
 #include <ored/portfolio/builders/commodityoption.hpp>
 #include <ored/portfolio/builders/cpicapfloor.hpp>
 #include <ored/portfolio/builders/creditdefaultswap.hpp>
+#include <ored/portfolio/builders/equityasianoption.hpp>
 #include <ored/portfolio/builders/equityforward.hpp>
 #include <ored/portfolio/builders/equityoption.hpp>
 #include <ored/portfolio/builders/forwardbond.hpp>
+#include <ored/portfolio/builders/fxasianoption.hpp>
 #include <ored/portfolio/builders/fxforward.hpp>
 #include <ored/portfolio/builders/fxoption.hpp>
 #include <ored/portfolio/builders/swap.hpp>
@@ -153,6 +157,12 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<FxEuropeanCSOptionEngineBuilder>());
     registerBuilder(boost::make_shared<FxAmericanOptionFDEngineBuilder>());
     registerBuilder(boost::make_shared<FxAmericanOptionBAWEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionMCDAAPEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionMCDAASEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionMCDGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionACGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionADGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionADGASEngineBuilder>());
 
     registerBuilder(boost::make_shared<CapFloorEngineBuilder>());
     registerBuilder(boost::make_shared<CapFlooredIborLegEngineBuilder>());
@@ -170,6 +180,12 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<EquityEuropeanCSOptionEngineBuilder>());
     registerBuilder(boost::make_shared<EquityAmericanOptionFDEngineBuilder>());
     registerBuilder(boost::make_shared<EquityAmericanOptionBAWEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionMCDAAPEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionMCDAASEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionMCDGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionACGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionADGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionADGASEngineBuilder>());
 
     registerBuilder(boost::make_shared<BondDiscountingEngineBuilder>());
     registerBuilder(boost::make_shared<DiscountingForwardBondEngineBuilder>());
@@ -184,6 +200,12 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<CommodityEuropeanCSOptionEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityAmericanOptionFDEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityAmericanOptionBAWEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionMCDAAPEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionMCDAASEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionMCDGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionACGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionADGAPEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionADGASEngineBuilder>());
 
     registerLegBuilder(boost::make_shared<FixedLegBuilder>());
     registerLegBuilder(boost::make_shared<ZeroCouponFixedLegBuilder>());

--- a/OREData/ored/portfolio/equityasianoption.cpp
+++ b/OREData/ored/portfolio/equityasianoption.cpp
@@ -52,12 +52,20 @@ void EquityAsianOption::fromXML(XMLNode* node) {
     AsianOptionTrade::fromXML(node);
     XMLNode* eqNode = XMLUtils::getChildNode(node, "EquityAsianOptionData");
     QL_REQUIRE(eqNode, "No EquityAsianOptionData node");
+
     option_.fromXML(XMLUtils::getChildNode(eqNode, "OptionData"));
     QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for EquityAsianOption.");
+    XMLNode* asianNode = XMLUtils::getChildNode(eqNode, "AsianData");
+    asianData_.fromXML(asianNode);
+
+    XMLNode* scheduleDataNode = XMLUtils::getChildNode(eqNode, "ScheduleData");
+    scheduleData_.fromXML(scheduleDataNode);
+
     XMLNode* tmp = XMLUtils::getChildNode(eqNode, "Underlying");
     if (!tmp)
         tmp = XMLUtils::getChildNode(eqNode, "Name");
     equityUnderlying_.fromXML(tmp);
+
     currency_ = XMLUtils::getChildValue(eqNode, "Currency", true);
     // Require explicit Strike
     strike_ = XMLUtils::getChildValueAsDouble(eqNode, "Strike", true);
@@ -70,6 +78,9 @@ XMLNode* EquityAsianOption::toXML(XMLDocument& doc) {
     XMLUtils::appendNode(node, eqNode);
 
     XMLUtils::appendNode(eqNode, option_.toXML(doc));
+    XMLUtils::appendNode(eqNode, asianData_.toXML(doc));
+    XMLUtils::appendNode(eqNode, scheduleData_.toXML(doc));
+
     XMLUtils::appendNode(eqNode, equityUnderlying_.toXML(doc));
     XMLUtils::addChild(doc, eqNode, "Currency", currency_);
     XMLUtils::addChild(doc, eqNode, "Strike", strike_);

--- a/OREData/ored/portfolio/equityasianoption.cpp
+++ b/OREData/ored/portfolio/equityasianoption.cpp
@@ -1,0 +1,82 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <boost/make_shared.hpp>
+#include <ored/portfolio/asianoption.hpp>
+#include <ored/portfolio/enginefactory.hpp>
+#include <ored/portfolio/equityasianoption.hpp>
+#include <ored/utilities/log.hpp>
+#include <ored/utilities/xmlutils.hpp>
+#include <ql/errors.hpp>
+#include <string>
+
+namespace ore {
+namespace data {
+
+void EquityAsianOption::build(const boost::shared_ptr<EngineFactory>& engineFactory) {
+    // Checks
+    QL_REQUIRE(quantity_ > 0, "Equity Asian option requires a positive quatity");
+    QL_REQUIRE(strike_ > 0, "Equity Asian option requires a positive strike");
+
+    // Set the assetName_ as it may have changed after lookup
+    assetName_ = equityName();
+
+    // Populate the index_ in case the option is automatic exercise
+    const boost::shared_ptr<Market>& market = engineFactory->market();
+    index_ = *market->equityCurve(assetName_, engineFactory->configuration(MarketContext::pricing));
+
+    // Build the trade using shared functionality in the base class
+    AsianOptionTrade::build(engineFactory);
+}
+
+std::map<AssetClass, std::set<std::string>> EquityAsianOption::underlyingIndices() const {
+    return {{AssetClass::EQ, std::set<std::string>({equityName()})}};
+}
+
+void EquityAsianOption::fromXML(XMLNode* node) {
+    AsianOptionTrade::fromXML(node);
+    XMLNode* eqNode = XMLUtils::getChildNode(node, "EquityAsianOptionData");
+    QL_REQUIRE(eqNode, "No EquityAsianOptionData node");
+    option_.fromXML(XMLUtils::getChildNode(eqNode, "OptionData"));
+    QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for EquityAsianOption.");
+    XMLNode* tmp = XMLUtils::getChildNode(eqNode, "Underlying");
+    if (!tmp)
+        tmp = XMLUtils::getChildNode(eqNode, "Name");
+    equityUnderlying_.fromXML(tmp);
+    currency_ = XMLUtils::getChildValue(eqNode, "Currency", true);
+    // Require explicit Strike
+    strike_ = XMLUtils::getChildValueAsDouble(eqNode, "Strike", true);
+    quantity_ = XMLUtils::getChildValueAsDouble(eqNode, "Quantity", true);
+}
+
+XMLNode* EquityAsianOption::toXML(XMLDocument& doc) {
+    XMLNode* node = AsianOptionTrade::toXML(doc);
+    XMLNode* eqNode = doc.allocNode("EquityAsianOptionData");
+    XMLUtils::appendNode(node, eqNode);
+
+    XMLUtils::appendNode(eqNode, option_.toXML(doc));
+    XMLUtils::appendNode(eqNode, equityUnderlying_.toXML(doc));
+    XMLUtils::addChild(doc, eqNode, "Currency", currency_);
+    XMLUtils::addChild(doc, eqNode, "Strike", strike_);
+    XMLUtils::addChild(doc, eqNode, "Quantity", quantity_);
+
+    return node;
+}
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/equityasianoption.hpp
+++ b/OREData/ored/portfolio/equityasianoption.hpp
@@ -1,0 +1,69 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/equityasianoption.hpp
+    \brief Equity Asian Option data model and serialization
+    \ingroup tradedata
+*/
+
+#pragma once
+
+#include <ored/portfolio/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Serializable Equity Asian Option
+/*!
+  \ingroup tradedata
+*/
+class EquityAsianOption : public AsianOptionTrade {
+public:
+    //! Default constructor
+    EquityAsianOption() : AsianOptionTrade(AssetClass::EQ) { tradeType_ = "EquityAsianOption"; }
+    //! Constructor
+    EquityAsianOption(Envelope& env, OptionData option, EquityUnderlying equityUnderlying, string currency, double strike,
+                 double quantity)
+        : AsianOptionTrade(env, AssetClass::EQ, option, equityUnderlying.name(), currency, strike, quantity),
+          equityUnderlying_(equityUnderlying) {
+        tradeType_ = "EquityAsianOption";
+    }
+
+    //! Build QuantLib/QuantExt instrument, link pricing engine
+    void build(const boost::shared_ptr<EngineFactory>&) override;
+
+    //! Add underlying Equity names
+    std::map<AssetClass, std::set<std::string>> underlyingIndices() const override;
+
+    //! \name Inspectors
+    //@{
+    const string& equityName() const { return equityUnderlying_.name(); }
+    //@}
+
+    //! \name Serialisation
+    //@{
+    virtual void fromXML(XMLNode* node) override;
+    virtual XMLNode* toXML(XMLDocument& doc) override;
+    //@}
+
+private:
+    EquityUnderlying equityUnderlying_;
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/equityasianoption.hpp
+++ b/OREData/ored/portfolio/equityasianoption.hpp
@@ -37,9 +37,10 @@ public:
     //! Default constructor
     EquityAsianOption() : AsianOptionTrade(AssetClass::EQ) { tradeType_ = "EquityAsianOption"; }
     //! Constructor
-    EquityAsianOption(Envelope& env, OptionData option, EquityUnderlying equityUnderlying, string currency, double strike,
-                 double quantity)
-        : AsianOptionTrade(env, AssetClass::EQ, option, equityUnderlying.name(), currency, strike, quantity),
+    EquityAsianOption(Envelope& env, OptionData option, OptionAsianData asianData, ScheduleData scheduleData,
+                      EquityUnderlying equityUnderlying, string currency, double strike, double quantity)
+        : AsianOptionTrade(env, AssetClass::EQ, option, asianData, scheduleData, equityUnderlying.name(), currency,
+                           strike, quantity),
           equityUnderlying_(equityUnderlying) {
         tradeType_ = "EquityAsianOption";
     }

--- a/OREData/ored/portfolio/fxasianoption.cpp
+++ b/OREData/ored/portfolio/fxasianoption.cpp
@@ -57,7 +57,12 @@ void FxAsianOption::fromXML(XMLNode* node) {
 
     option_.fromXML(XMLUtils::getChildNode(fxNode, "OptionData"));
     QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for FxAsianOption.");
+    XMLNode* asianNode = XMLUtils::getChildNode(fxNode, "AsianData");
+    asianData_.fromXML(asianNode);
     
+    XMLNode* scheduleDataNode = XMLUtils::getChildNode(fxNode, "ScheduleData");
+    scheduleData_.fromXML(scheduleDataNode);
+
     assetName_ = XMLUtils::getChildValue(fxNode, "BoughtCurrency", true);
     currency_ = XMLUtils::getChildValue(fxNode, "SoldCurrency", true);
     double boughtAmount = XMLUtils::getChildValueAsDouble(fxNode, "BoughtAmount", true);
@@ -76,6 +81,9 @@ XMLNode* FxAsianOption::toXML(XMLDocument& doc) {
     XMLUtils::appendNode(node, fxNode);
 
     XMLUtils::appendNode(fxNode, option_.toXML(doc));
+    XMLUtils::appendNode(fxNode, asianData_.toXML(doc));
+    XMLUtils::appendNode(fxNode, scheduleData_.toXML(doc));
+
     XMLUtils::addChild(doc, fxNode, "BoughtCurrency", boughtCurrency());
     XMLUtils::addChild(doc, fxNode, "BoughtAmount", boughtAmount());
     XMLUtils::addChild(doc, fxNode, "SoldCurrency", soldCurrency());

--- a/OREData/ored/portfolio/fxasianoption.cpp
+++ b/OREData/ored/portfolio/fxasianoption.cpp
@@ -1,0 +1,91 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <ored/portfolio/fxasianoption.hpp>
+#include <ored/utilities/xmlutils.hpp>
+#include <ql/errors.hpp>
+
+namespace ore {
+namespace data {
+
+void FxAsianOption::build(const boost::shared_ptr<EngineFactory>& engineFactory) {
+    // Checks
+    QL_REQUIRE(quantity_ > 0, "Fx Asian option requires a positive quatity");
+    QL_REQUIRE(strike_ > 0, "Fx Asian option requires a positive strike");
+
+    const boost::shared_ptr<Market>& market = engineFactory->market();
+
+    // Check that we can populate index_. Reused logic from AutomaticExercise FX vanilla options
+    QL_REQUIRE(!fxIndex_.empty(), "FX Asian option trade "
+                                        << id()
+                                        << " has automatic exercise so the FXIndex node needs to be populated.");
+
+    // The strike is the number of units of sold currency (currency_) per unit of bought currency (assetName_).
+    // So, the convention here is that the sold currency is domestic and the bought currency is foreign.
+    // Note: intentionally use null calendar and 0 day fixing lag here because we will ask the FX index for its
+    //       value on the expiry date without adjustment.
+    index_ = buildFxIndex(fxIndex_, currency_, assetName_, market,
+                            engineFactory->configuration(MarketContext::pricing), "NullCalendar", 0);
+
+    // Populate the external index name so that fixings work.
+    indexName_ = fxIndex_;
+
+    // Build the trade using the shared functionality in the base class.
+    AsianOptionTrade::build(engineFactory);
+}
+
+void FxAsianOption::fromXML(XMLNode* node) {
+    AsianOptionTrade::fromXML(node);
+
+    XMLNode* fxNode = XMLUtils::getChildNode(node, "FxAsianOptionData");
+    QL_REQUIRE(fxNode, "No FxAsianOptionData Node");
+
+    option_.fromXML(XMLUtils::getChildNode(fxNode, "OptionData"));
+    QL_REQUIRE(option_.payoffType() == "Asian", "Expected PayoffType Asian for FxAsianOption.");
+    
+    assetName_ = XMLUtils::getChildValue(fxNode, "BoughtCurrency", true);
+    currency_ = XMLUtils::getChildValue(fxNode, "SoldCurrency", true);
+    double boughtAmount = XMLUtils::getChildValueAsDouble(fxNode, "BoughtAmount", true);
+    double soldAmount = XMLUtils::getChildValueAsDouble(fxNode, "SoldAmount", true);
+    strike_ = soldAmount / boughtAmount;
+    quantity_ = boughtAmount;
+    
+    fxIndex_ = XMLUtils::getChildValue(fxNode, "FXIndex", true);
+}
+
+XMLNode* FxAsianOption::toXML(XMLDocument& doc) {
+    // TODO: Should call parent class to xml?
+    XMLNode* node = Trade::toXML(doc);
+
+    XMLNode* fxNode = doc.allocNode("FxAsianOptionData");
+    XMLUtils::appendNode(node, fxNode);
+
+    XMLUtils::appendNode(fxNode, option_.toXML(doc));
+    XMLUtils::addChild(doc, fxNode, "BoughtCurrency", boughtCurrency());
+    XMLUtils::addChild(doc, fxNode, "BoughtAmount", boughtAmount());
+    XMLUtils::addChild(doc, fxNode, "SoldCurrency", soldCurrency());
+    XMLUtils::addChild(doc, fxNode, "SoldAmount", soldAmount());
+
+    if (!fxIndex_.empty())
+        XMLUtils::addChild(doc, fxNode, "FXIndex", fxIndex_);
+
+    return node;
+}
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/fxasianoption.hpp
+++ b/OREData/ored/portfolio/fxasianoption.hpp
@@ -1,0 +1,72 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file portfolio/fxasianoption.hpp
+    \brief Fx Asian Option data model and serialization
+    \ingroup tradedata
+*/
+
+#pragma once
+
+#include <ored/portfolio/asianoption.hpp>
+
+namespace ore {
+namespace data {
+
+//! Serializable Fx Asian Option
+/*!
+  \ingroup tradedata
+*/
+class FxAsianOption : public AsianOptionTrade {
+public:
+    //! Default constructor
+    FxAsianOption() : AsianOptionTrade(AssetClass::FX) { tradeType_ = "FxAsianOption"; }
+    //! Constructor
+    FxAsianOption(Envelope& env, OptionData option, string boughtCurrency, double boughtAmount, string soldCurrency,
+                  double soldAmount, const std::string& fxIndex)
+        : AsianOptionTrade(env, AssetClass::FX, option, boughtCurrency, soldCurrency, soldAmount / boughtAmount,
+                           boughtAmount),
+          fxIndex_(fxIndex) {
+        tradeType_ = "FxAsianOption";
+    }
+
+    //! Build QuantLib/QuantExt instrument, link pricing engine
+    void build(const boost::shared_ptr<EngineFactory>&) override;
+
+    //! \name Inspectors
+    //@{
+    const string& boughtCurrency() const { return assetName_; }
+    double boughtAmount() const { return quantity_; }
+    const string& soldCurrency() const { return currency_; }
+    double soldAmount() const { return strike_ * quantity_; }
+    const std::string& fxIndex() const { return fxIndex_; }
+    //@}
+
+    //! \name Serialisation
+    //@{
+    virtual void fromXML(XMLNode* node) override;
+    virtual XMLNode* toXML(XMLDocument& doc) override;
+    //@}
+
+private:
+    //! Needed for past fixings
+    std::string fxIndex_;
+};
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/fxasianoption.hpp
+++ b/OREData/ored/portfolio/fxasianoption.hpp
@@ -37,10 +37,11 @@ public:
     //! Default constructor
     FxAsianOption() : AsianOptionTrade(AssetClass::FX) { tradeType_ = "FxAsianOption"; }
     //! Constructor
-    FxAsianOption(Envelope& env, OptionData option, string boughtCurrency, double boughtAmount, string soldCurrency,
-                  double soldAmount, const std::string& fxIndex)
-        : AsianOptionTrade(env, AssetClass::FX, option, boughtCurrency, soldCurrency, soldAmount / boughtAmount,
-                           boughtAmount),
+    FxAsianOption(Envelope& env, OptionData option, OptionAsianData asianData, ScheduleData scheduleData,
+                  string boughtCurrency, double boughtAmount, string soldCurrency, double soldAmount,
+                  const std::string& fxIndex)
+        : AsianOptionTrade(env, AssetClass::FX, option, asianData, scheduleData, boughtCurrency, soldCurrency,
+                           soldAmount / boughtAmount, boughtAmount),
           fxIndex_(fxIndex) {
         tradeType_ = "FxAsianOption";
     }

--- a/OREData/ored/portfolio/optionasiandata.cpp
+++ b/OREData/ored/portfolio/optionasiandata.cpp
@@ -26,50 +26,24 @@ using QuantLib::Average;
 namespace ore {
 namespace data {
 
-OptionAsianData::OptionAsianData() 
-    : asianType_(AsianType::Price), averageType_(Average::Type::Arithmetic), fixingDates_(std::vector<QuantLib::Date>()), strFixingDates_(std::vector<string>()) {}
+OptionAsianData::OptionAsianData() : asianType_(AsianType::Price), averageType_(Average::Type::Arithmetic) {}
 
-OptionAsianData::OptionAsianData(const AsianType& asianType, const Average::Type& averageType,
-                                 const vector<string>& strFixingDates)
-    : asianType_(asianType), averageType_(averageType), strFixingDates_(strFixingDates) {
-    init();
-}
-
-OptionAsianData::OptionAsianData(const AsianType& asianType, const Average::Type& averageType,
-                                 const vector<QuantLib::Date>& fixingDates)
-    : asianType_(asianType), averageType_(averageType), fixingDates_(fixingDates) {
-    QL_REQUIRE(fixingDates_.size() > 0, "Expected 1 or more FixingDate for AsianData.");
-}
+OptionAsianData::OptionAsianData(const AsianType& asianType, const Average::Type& averageType)
+    : asianType_(asianType), averageType_(averageType) {}
 
 void OptionAsianData::fromXML(XMLNode* node) {
     XMLUtils::checkNode(node, "AsianData");
     std::string strAsianType = XMLUtils::getChildValue(node, "AsianType", true);
     populateAsianType(strAsianType);
     averageType_ = parseAverageType(XMLUtils::getChildValue(node, "AverageType", true));
-    strFixingDates_ = XMLUtils::getChildrenValues(node, "FixingDates", "FixingDate", true);
-    init();
 }
 
 XMLNode* OptionAsianData::toXML(XMLDocument& doc) {
     XMLNode* node = doc.allocNode("AsianData");
     XMLUtils::addChild(doc, node, "AsianType", to_string(asianType_));
     XMLUtils::addChild(doc, node, "AverageType", to_string(averageType_));
-    if (strFixingDates_.size() == 0) {
-        // Need to populate if constructed from vector of proper dates
-        strFixingDates_.resize(fixingDates_.size());
-        std::transform(fixingDates_.begin(), fixingDates_.end(), strFixingDates_.begin(),
-                       [](QuantLib::Date date) -> std::string { return to_string(date); });
-    }
-    XMLUtils::addChildren(doc, node, "FixingDates", "FixingDate", strFixingDates_);
+
     return node;
-}
-
-void OptionAsianData::init() {
-    QL_REQUIRE(strFixingDates_.size() > 0, "Expected 1 or more FixingDate for AsianData.");
-
-    fixingDates_.resize(strFixingDates_.size());
-    std::transform(strFixingDates_.begin(), strFixingDates_.end(), fixingDates_.begin(),
-                   [](string strDate) -> QuantLib::Date { return parseDate(strDate); });
 }
 
 void OptionAsianData::populateAsianType(const std::string& s) {

--- a/OREData/ored/portfolio/optionasiandata.cpp
+++ b/OREData/ored/portfolio/optionasiandata.cpp
@@ -1,0 +1,97 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <ored/portfolio/optionasiandata.hpp>
+#include <ored/utilities/parsers.hpp>
+#include <ored/utilities/to_string.hpp>
+#include <algorithm>
+
+using QuantLib::Average;
+
+namespace ore {
+namespace data {
+
+OptionAsianData::OptionAsianData() 
+    : asianType_(AsianType::Price), averageType_(Average::Type::Arithmetic), fixingDates_(std::vector<QuantLib::Date>()), strFixingDates_(std::vector<string>()) {}
+
+OptionAsianData::OptionAsianData(const AsianType& asianType, const Average::Type& averageType,
+                                 const vector<string>& strFixingDates)
+    : asianType_(asianType), averageType_(averageType), strFixingDates_(strFixingDates) {
+    init();
+}
+
+OptionAsianData::OptionAsianData(const AsianType& asianType, const Average::Type& averageType,
+                                 const vector<QuantLib::Date>& fixingDates)
+    : asianType_(asianType), averageType_(averageType), fixingDates_(fixingDates) {
+    QL_REQUIRE(fixingDates_.size() > 0, "Expected 1 or more FixingDate for AsianData.");
+}
+
+void OptionAsianData::fromXML(XMLNode* node) {
+    XMLUtils::checkNode(node, "AsianData");
+    std::string strAsianType = XMLUtils::getChildValue(node, "AsianType", true);
+    populateAsianType(strAsianType);
+    averageType_ = parseAverageType(XMLUtils::getChildValue(node, "AverageType", true));
+    strFixingDates_ = XMLUtils::getChildrenValues(node, "FixingDates", "FixingDate", true);
+    init();
+}
+
+XMLNode* OptionAsianData::toXML(XMLDocument& doc) {
+    XMLNode* node = doc.allocNode("AsianData");
+    XMLUtils::addChild(doc, node, "AsianType", to_string(asianType_));
+    XMLUtils::addChild(doc, node, "AverageType", to_string(averageType_));
+    if (strFixingDates_.size() == 0) {
+        // Need to populate if constructed from vector of proper dates
+        strFixingDates_.resize(fixingDates_.size());
+        std::transform(fixingDates_.begin(), fixingDates_.end(), strFixingDates_.begin(),
+                       [](QuantLib::Date date) -> std::string { return to_string(date); });
+    }
+    XMLUtils::addChildren(doc, node, "FixingDates", "FixingDate", strFixingDates_);
+    return node;
+}
+
+void OptionAsianData::init() {
+    QL_REQUIRE(strFixingDates_.size() > 0, "Expected 1 or more FixingDate for AsianData.");
+
+    fixingDates_.resize(strFixingDates_.size());
+    std::transform(strFixingDates_.begin(), strFixingDates_.end(), fixingDates_.begin(),
+                   [](string strDate) -> QuantLib::Date { return parseDate(strDate); });
+}
+
+void OptionAsianData::populateAsianType(const std::string& s) {
+    if (s == "Price") {
+        asianType_ = AsianType::Price;
+    } else if (s == "Strike") {
+        asianType_ = AsianType::Strike;
+    } else {
+        QL_FAIL("expected AsianType Price or Strike.");
+    }
+}
+
+std::ostream& operator<<(std::ostream& out, const OptionAsianData::AsianType& asianType) {
+    switch (asianType) {
+    case OptionAsianData::AsianType::Price:
+        return out << "Price";
+    case OptionAsianData::AsianType::Strike:
+        return out << "Strike";
+    default:
+        QL_FAIL("Could not convert the asianType enum value to string.");
+    }
+}
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/optionasiandata.hpp
+++ b/OREData/ored/portfolio/optionasiandata.hpp
@@ -1,0 +1,82 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file ored/portfolio/optionasiandata.hpp
+    \brief asian option data model and serialization
+    \ingroup tradedata
+*/
+
+#pragma once
+
+#include <ored/utilities/xmlutils.hpp>
+#include <ql/instruments/averagetype.hpp>
+#include <ql/time/date.hpp>
+
+namespace ore {
+namespace data {
+
+/*! Serializable object holding asian option data for options with payoff type Asian.
+    \ingroup tradedata
+*/
+class OptionAsianData : public XMLSerializable {
+public:
+    enum class AsianType { Price, Strike };
+
+    //! Default constructor
+    OptionAsianData();
+
+    //! Constructor taking an Asian type, average type, and vector of fixing string dates.
+    OptionAsianData(const AsianType& asianType, const QuantLib::Average::Type& averageType,
+                    const std::vector<std::string>& strFixingDates);
+
+    //! Constructor taking an Asian type, average type, and vector of fixing dates.
+    OptionAsianData(const AsianType& asianType, const QuantLib::Average::Type& averageType,
+                    const std::vector<QuantLib::Date>& fixingDates);
+
+    //! \name Inspectors
+    //@{
+    const AsianType& asianType() const { return asianType_; }
+    const QuantLib::Average::Type& averageType() const { return averageType_; }
+    const std::vector<QuantLib::Date>& fixingDates() const { return fixingDates_; }
+    //@}
+
+    //! \name Serialisation
+    //@{
+    virtual void fromXML(XMLNode* node) override;
+    virtual XMLNode* toXML(XMLDocument& doc) override;
+    //@}
+
+private:
+    std::vector<std::string> strFixingDates_;
+
+    AsianType asianType_;
+    QuantLib::Average::Type averageType_;
+    std::vector<QuantLib::Date> fixingDates_;
+
+    //! Initialisation
+    void init();
+
+    //! Populate the value of asianType_ from string
+    void populateAsianType(const std::string& s);
+};
+
+//! Print AsianType enum values.
+std::ostream& operator<<(std::ostream& out, const OptionAsianData::AsianType& asianType);
+
+} // namespace data
+} // namespace ore

--- a/OREData/ored/portfolio/optionasiandata.hpp
+++ b/OREData/ored/portfolio/optionasiandata.hpp
@@ -30,7 +30,7 @@
 namespace ore {
 namespace data {
 
-/*! Serializable object holding asian option data for options with payoff type Asian.
+/*! Serializable object holding Asian option data for options with payoff type Asian.
     \ingroup tradedata
 */
 class OptionAsianData : public XMLSerializable {
@@ -40,19 +40,13 @@ public:
     //! Default constructor
     OptionAsianData();
 
-    //! Constructor taking an Asian type, average type, and vector of fixing string dates.
-    OptionAsianData(const AsianType& asianType, const QuantLib::Average::Type& averageType,
-                    const std::vector<std::string>& strFixingDates);
-
-    //! Constructor taking an Asian type, average type, and vector of fixing dates.
-    OptionAsianData(const AsianType& asianType, const QuantLib::Average::Type& averageType,
-                    const std::vector<QuantLib::Date>& fixingDates);
+    //! Constructor taking an Asian type, average type
+    OptionAsianData(const AsianType& asianType, const QuantLib::Average::Type& averageType);
 
     //! \name Inspectors
     //@{
     const AsianType& asianType() const { return asianType_; }
     const QuantLib::Average::Type& averageType() const { return averageType_; }
-    const std::vector<QuantLib::Date>& fixingDates() const { return fixingDates_; }
     //@}
 
     //! \name Serialisation
@@ -62,14 +56,9 @@ public:
     //@}
 
 private:
-    std::vector<std::string> strFixingDates_;
 
     AsianType asianType_;
     QuantLib::Average::Type averageType_;
-    std::vector<QuantLib::Date> fixingDates_;
-
-    //! Initialisation
-    void init();
 
     //! Populate the value of asianType_ from string
     void populateAsianType(const std::string& s);

--- a/OREData/ored/portfolio/optiondata.cpp
+++ b/OREData/ored/portfolio/optiondata.cpp
@@ -1,6 +1,5 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
- Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -69,15 +68,6 @@ void OptionData::fromXML(XMLNode* node) {
         paymentData_ = OptionPaymentData();
         paymentData_->fromXML(n);
     }
-
-    asianData_ = boost::none;
-    XMLNode* n = XMLUtils::getChildNode(node, "AsianData");
-    if (payoffType_ == "Asian")
-        QL_REQUIRE(n, "AsianData node with fixings required for PayoffType Asian.");
-    if (n) {
-        asianData_ = OptionAsianData();
-        asianData_->fromXML(n);
-    }
 }
 
 XMLNode* OptionData::toXML(XMLDocument& doc) {
@@ -122,10 +112,6 @@ XMLNode* OptionData::toXML(XMLDocument& doc) {
 
     if (paymentData_) {
         XMLUtils::appendNode(node, paymentData_->toXML(doc));
-    }
-
-    if (asianData_) {
-        XMLUtils::appendNode(node, asianData_->toXML(doc));
     }
 
     return node;

--- a/OREData/ored/portfolio/optiondata.cpp
+++ b/OREData/ored/portfolio/optiondata.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -68,6 +69,15 @@ void OptionData::fromXML(XMLNode* node) {
         paymentData_ = OptionPaymentData();
         paymentData_->fromXML(n);
     }
+
+    asianData_ = boost::none;
+    XMLNode* n = XMLUtils::getChildNode(node, "AsianData");
+    if (payoffType_ == "Asian")
+        QL_REQUIRE(n, "AsianData node with fixings required for PayoffType Asian.");
+    if (n) {
+        asianData_ = OptionAsianData();
+        asianData_->fromXML(n);
+    }
 }
 
 XMLNode* OptionData::toXML(XMLDocument& doc) {
@@ -112,6 +122,10 @@ XMLNode* OptionData::toXML(XMLDocument& doc) {
 
     if (paymentData_) {
         XMLUtils::appendNode(node, paymentData_->toXML(doc));
+    }
+
+    if (asianData_) {
+        XMLUtils::appendNode(node, asianData_->toXML(doc));
     }
 
     return node;

--- a/OREData/ored/portfolio/optiondata.hpp
+++ b/OREData/ored/portfolio/optiondata.hpp
@@ -1,6 +1,5 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
- Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -24,7 +23,6 @@
 
 #pragma once
 
-#include <ored/portfolio/optionasiandata.hpp>
 #include <ored/portfolio/optionexercisedata.hpp>
 #include <ored/portfolio/optionpaymentdata.hpp>
 #include <ored/portfolio/schedule.hpp>
@@ -50,8 +48,7 @@ public:
                string exerciseFeeSettlementCalendar = "", string exerciseFeeSettlementConvention = "",
                string payoffType = "", const boost::optional<bool>& automaticExercise = boost::none,
                const boost::optional<OptionExerciseData>& exerciseData = boost::none,
-               const boost::optional<OptionPaymentData>& paymentData = boost::none,
-               const boost::optional<OptionAsianData>& asianData = boost::none)
+               const boost::optional<OptionPaymentData>& paymentData = boost::none)
         : longShort_(longShort), callPut_(callPut), payoffType_(payoffType), style_(style),
           payoffAtExpiry_(payoffAtExpiry), exerciseDates_(exerciseDates), noticePeriod_(noticePeriod),
           noticeCalendar_(noticeCalendar), noticeConvention_(noticeConvention), settlement_(settlement),
@@ -60,8 +57,7 @@ public:
           exerciseFeeTypes_(exerciseFeeTypes), exerciseFeeSettlementPeriod_(exerciseFeeSettlementPeriod),
           exerciseFeeSettlementCalendar_(exerciseFeeSettlementCalendar),
           exerciseFeeSettlementConvention_(exerciseFeeSettlementConvention), exercisePrices_(exercisePrices),
-          automaticExercise_(automaticExercise), exerciseData_(exerciseData), paymentData_(paymentData),
-          asianData_(asianData) {}
+          automaticExercise_(automaticExercise), exerciseData_(exerciseData), paymentData_(paymentData) {}
 
     //! \name Inspectors
     //@{
@@ -92,7 +88,6 @@ public:
     }
     const boost::optional<OptionExerciseData>& exerciseData() const { return exerciseData_; }
     const boost::optional<OptionPaymentData>& paymentData() const { return paymentData_; }
-    const boost::optional<OptionAsianData>& asianData() const { return asianData_; }
     //@}
 
     //! \name Serialisation
@@ -126,7 +121,6 @@ private:
     boost::optional<bool> automaticExercise_;
     boost::optional<OptionExerciseData> exerciseData_;
     boost::optional<OptionPaymentData> paymentData_;
-    boost::optional<OptionAsianData> asianData_;
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/portfolio/optiondata.hpp
+++ b/OREData/ored/portfolio/optiondata.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -23,6 +24,7 @@
 
 #pragma once
 
+#include <ored/portfolio/optionasiandata.hpp>
 #include <ored/portfolio/optionexercisedata.hpp>
 #include <ored/portfolio/optionpaymentdata.hpp>
 #include <ored/portfolio/schedule.hpp>
@@ -48,7 +50,8 @@ public:
                string exerciseFeeSettlementCalendar = "", string exerciseFeeSettlementConvention = "",
                string payoffType = "", const boost::optional<bool>& automaticExercise = boost::none,
                const boost::optional<OptionExerciseData>& exerciseData = boost::none,
-               const boost::optional<OptionPaymentData>& paymentData = boost::none)
+               const boost::optional<OptionPaymentData>& paymentData = boost::none,
+               const boost::optional<OptionAsianData>& asianData = boost::none)
         : longShort_(longShort), callPut_(callPut), payoffType_(payoffType), style_(style),
           payoffAtExpiry_(payoffAtExpiry), exerciseDates_(exerciseDates), noticePeriod_(noticePeriod),
           noticeCalendar_(noticeCalendar), noticeConvention_(noticeConvention), settlement_(settlement),
@@ -57,7 +60,8 @@ public:
           exerciseFeeTypes_(exerciseFeeTypes), exerciseFeeSettlementPeriod_(exerciseFeeSettlementPeriod),
           exerciseFeeSettlementCalendar_(exerciseFeeSettlementCalendar),
           exerciseFeeSettlementConvention_(exerciseFeeSettlementConvention), exercisePrices_(exercisePrices),
-          automaticExercise_(automaticExercise), exerciseData_(exerciseData), paymentData_(paymentData) {}
+          automaticExercise_(automaticExercise), exerciseData_(exerciseData), paymentData_(paymentData),
+          asianData_(asianData) {}
 
     //! \name Inspectors
     //@{
@@ -88,6 +92,7 @@ public:
     }
     const boost::optional<OptionExerciseData>& exerciseData() const { return exerciseData_; }
     const boost::optional<OptionPaymentData>& paymentData() const { return paymentData_; }
+    const boost::optional<OptionAsianData>& asianData() const { return asianData_; }
     //@}
 
     //! \name Serialisation
@@ -121,6 +126,7 @@ private:
     boost::optional<bool> automaticExercise_;
     boost::optional<OptionExerciseData> exerciseData_;
     boost::optional<OptionPaymentData> paymentData_;
+    boost::optional<OptionAsianData> asianData_;
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/portfolio/tradefactory.cpp
+++ b/OREData/ored/portfolio/tradefactory.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -18,14 +19,17 @@
 
 #include <ored/portfolio/bond.hpp>
 #include <ored/portfolio/capfloor.hpp>
+#include <ored/portfolio/commodityasianoption.hpp>
 #include <ored/portfolio/commodityforward.hpp>
 #include <ored/portfolio/commodityoption.hpp>
 #include <ored/portfolio/creditdefaultswap.hpp>
+#include <ored/portfolio/equityasianoption.hpp>
 #include <ored/portfolio/equityforward.hpp>
 #include <ored/portfolio/equityoption.hpp>
 #include <ored/portfolio/equityswap.hpp>
 #include <ored/portfolio/forwardbond.hpp>
 #include <ored/portfolio/forwardrateagreement.hpp>
+#include <ored/portfolio/fxasianoption.hpp>
 #include <ored/portfolio/fxforward.hpp>
 #include <ored/portfolio/fxoption.hpp>
 #include <ored/portfolio/fxswap.hpp>
@@ -55,6 +59,9 @@ TradeFactory::TradeFactory(std::map<string, boost::shared_ptr<AbstractTradeBuild
     addBuilder("CreditDefaultSwap", boost::make_shared<TradeBuilder<CreditDefaultSwap>>());
     addBuilder("CommodityForward", boost::make_shared<TradeBuilder<CommodityForward>>());
     addBuilder("CommodityOption", boost::make_shared<TradeBuilder<CommodityOption>>());
+    addBuilder("EquityAsianOption", boost::make_shared<TradeBuilder<EquityAsianOption>>());
+    addBuilder("CommodityAsianOption", boost::make_shared<TradeBuilder<CommodityAsianOption>>());
+    addBuilder("FxAsianOption", boost::make_shared<TradeBuilder<FxAsianOption>>());
     if (extraBuilders.size() > 0)
         addExtraBuilders(extraBuilders);
 }

--- a/OREData/ored/utilities/parsers.cpp
+++ b/OREData/ored/utilities/parsers.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -974,6 +975,16 @@ std::ostream& operator<<(std::ostream& os, Extrapolation extrap) {
         return os << "Flat";
     default:
         QL_FAIL("Unknown Extrapolation");
+    }
+}
+
+Average::Type parseAverageType(const std::string& s) {
+    if (s == "Arithmetic") {
+        return Average::Type::Arithmetic;
+    } else if (s == "Geometric") {
+        return Average::Type::Geometric;
+    } else {
+        QL_FAIL("Average::Type '" << s << "' not recognized. Should be Arithmetic or Geometric");
     }
 }
 

--- a/OREData/ored/utilities/parsers.hpp
+++ b/OREData/ored/utilities/parsers.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -29,6 +30,7 @@
 #include <ql/currency.hpp>
 #include <ql/exercise.hpp>
 #include <ql/experimental/fx/deltavolquote.hpp>
+#include <ql/instruments/averagetype.hpp>
 #include <ql/instruments/swaption.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
@@ -296,6 +298,8 @@ Extrapolation parseExtrapolation(const std::string& s);
 
 //! Write Extrapolation, \p extrap, to stream.
 std::ostream& operator<<(std::ostream& os, Extrapolation extrap);
+
+QuantLib::Average::Type parseAverageType(const std::string& s);
 
 } // namespace data
 } // namespace ore

--- a/OREData/test/OREDataTestSuite.vcxproj
+++ b/OREData/test/OREDataTestSuite.vcxproj
@@ -642,6 +642,7 @@
     <ClCompile Include="ccyswapwithresets.cpp" />
     <ClCompile Include="cds.cpp" />
     <ClCompile Include="cms.cpp" />
+    <ClCompile Include="commodityasianoption.cpp" />
     <ClCompile Include="commoditycurve.cpp" />
     <ClCompile Include="commoditycurveconfig.cpp" />
     <ClCompile Include="commodityoption.cpp" />
@@ -656,12 +657,14 @@
     <ClCompile Include="crossassetmodeldata.cpp" />
     <ClCompile Include="curveconfig.cpp" />
     <ClCompile Include="digitalcms.cpp" />
+    <ClCompile Include="equityasianoption.cpp" />
     <ClCompile Include="equitymarketdata.cpp" />
     <ClCompile Include="equityswap.cpp" />
     <ClCompile Include="equitytrades.cpp" />
     <ClCompile Include="expiry.cpp" />
     <ClCompile Include="fittedbondcurve.cpp" />
     <ClCompile Include="fixings.cpp" />
+    <ClCompile Include="fxasianoption.cpp" />
     <ClCompile Include="fxoption.cpp" />
     <ClCompile Include="fxswap.cpp" />
     <ClCompile Include="fxtriangulation.cpp" />
@@ -669,6 +672,7 @@
     <ClCompile Include="inflationcapfloor.cpp" />
     <ClCompile Include="legdata.cpp" />
     <ClCompile Include="mxnircurves.cpp" />
+    <ClCompile Include="optionasiandata.cpp" />
     <ClCompile Include="optionpaymentdata.cpp" />
     <ClCompile Include="ored_commodityforward.cpp" />
     <ClCompile Include="parser.cpp" />

--- a/OREData/test/OREDataTestSuite.vcxproj.filters
+++ b/OREData/test/OREDataTestSuite.vcxproj.filters
@@ -139,5 +139,17 @@
     <ClCompile Include="optionpaymentdata.cpp">
       <Filter>source</Filter>
     </ClCompile>
+    <ClCompile Include="commodityasianoption.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
+    <ClCompile Include="optionasiandata.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
+    <ClCompile Include="fxasianoption.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
+    <ClCompile Include="equityasianoption.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/OREData/test/commodityasianoption.cpp
+++ b/OREData/test/commodityasianoption.cpp
@@ -1,0 +1,291 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <oret/toplevelfixture.hpp>
+
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/make_shared.hpp>
+
+#include <ql/currencies/america.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/pricingengines/blackformula.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvariancecurve.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+
+#include <qle/termstructures/pricecurve.hpp>
+#include <qle/math/flatextrapolation.hpp>
+
+#include <ored/marketdata/marketimpl.hpp>
+#include <ored/portfolio/builders/commodityasianoption.hpp>
+#include <ored/portfolio/commodityasianoption.hpp>
+#include <ored/portfolio/portfolio.hpp>
+#include <ored/utilities/to_string.hpp>
+
+using namespace std;
+using namespace boost::unit_test_framework;
+using namespace boost::algorithm;
+using namespace QuantLib;
+using namespace QuantExt;
+using namespace ore::data;
+
+namespace {
+
+class TestMarket : public MarketImpl {
+public:
+    TestMarket(const Real spot, const Date& expiry, const Rate riskFreeRate, const Rate convenienceYield,
+               const Volatility flatVolatility) {
+        // Reference date and common day counter
+        asof_ = Date(01, Feb, 2021);
+        //Actual365Fixed dayCounter;
+        DayCounter dayCounter = Actual360();
+
+        // Add USD discount curve
+        Handle<YieldTermStructure> discount(boost::make_shared<FlatForward>(asof_, riskFreeRate, dayCounter));
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::Discount, "USD")] = discount;
+
+        // Add ALU_USD price curve
+        vector<Date> dates = {asof_, expiry};
+        vector<Real> prices = {spot, spot * std::exp((riskFreeRate - convenienceYield) * dayCounter.yearFraction(asof_, expiry))};
+        Handle<PriceTermStructure> priceCurve(
+            boost::make_shared<InterpolatedPriceCurve<QuantExt::LinearFlat>>(asof_, dates, prices, dayCounter, USDCurrency()));
+        commodityCurves_[make_pair(Market::defaultConfiguration, "ALU_USD")] = priceCurve;
+
+        // Add ALU_USD volatilities
+        Handle<BlackVolTermStructure> volatility(
+            boost::make_shared<BlackConstantVol>(asof_, TARGET(), flatVolatility, dayCounter));
+        commodityVols_[make_pair(Market::defaultConfiguration, "ALU_USD")] = volatility;
+    }
+};
+
+struct DiscreteAsianTestData {
+    Option::Type type;
+    Real spot;
+    Real strike;
+    Rate convenienceYield;
+    Rate riskFreeRate;
+    Time firstFixing;
+    Time length;
+    Size fixings;
+    Volatility volatility;
+    Real expectedNPV;
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(OREDataTestSuite, ore::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(CommodityAsianOptionTests)
+
+BOOST_AUTO_TEST_CASE(testCommodityAsianOptionTradeBuilding) {
+
+    BOOST_TEST_MESSAGE("Testing commodity Asian option trade building with constant vol term structure");
+
+    // Data from "The Complete Guide to Option Pricing Formulas", E. G. Haug, 2007, p. 194
+    // std::vector<DiscreteAsianTestData> asians{
+    //    {95, 100, 0.08, 0.03, 0 * Days, 7 * Days, 180 * Days, 0.10, 27, 0.2719},
+    //    {105, 100, 0.08, 0.03, 0 * Days, 1 * Days, 180 * Days, 0.50, 27, 11.1094},
+    //    {95, 100, 0.08, 0.03, 70 * Days, 1 * Days, 180 * Days, 0.10, 27, 0.8805},
+    //    {105, 100, 0.08, 0.03, 70 * Days, 1 * Days, 180 * Days, 0.50, 27, 14.8936},
+    //    {95, 100, 0.08, 0.03, 140 * Days, 1 * Days, 180 * Days, 0.10, 27, 1.4839},
+    //    {105, 100, 0.08, 0.03, 140 * Days, 1 * Days, 180 * Days, 0.50, 27, 17.6981}};
+
+    // Data from "Asian Option", Levy, 1997 in "Exotic Options: The State of the Art",
+    // edited by Clewlow, Strickland
+    // Tests with > 100 fixings are skipped here for speed, QL already tests these
+    std::vector<DiscreteAsianTestData> asians = {
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 2, 0.13, 1.3942835683},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 4, 0.13, 1.5852442983},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 8, 0.13, 1.66970673},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 12, 0.13, 1.6980019214},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 26, 0.13, 1.7255070456},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 52, 0.13, 1.7401553533},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 100, 0.13, 1.7478303712},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 2, 0.13, 1.8496053697},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.0111495205},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.0852138818},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.1105094397},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.1346526695},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.147489651},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.154728109},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 2, 0.13, 2.63315092584},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.76723962361},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.83124836881},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.84290301412},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.88179560417},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.88447044543},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.89985329603}};
+
+    Date asof = Date(01, Feb, 2021);
+    Envelope env("CP1");
+    boost::shared_ptr<EngineFactory> engineFactory;
+    boost::shared_ptr<Market> market;
+
+    for (const auto& a : asians) {
+        Time deltaT = a.length / (a.fixings - 1);
+        Date expiry;
+        vector<Date> fixingDates(a.fixings);
+        for (Size i = 0; i < a.fixings; ++i) {
+            fixingDates[i] = (asof + static_cast<Integer>((a.firstFixing + i * deltaT) * 360 + 0.5));
+        }
+        expiry = fixingDates[a.fixings - 1];
+
+        market = boost::make_shared<TestMarket>(a.spot, expiry, a.riskFreeRate, a.convenienceYield, a.volatility);
+        boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
+        std::string productName = "CommodityAsianOptionArithmeticPrice";
+        engineData->model(productName) = "BlackScholesMerton";
+        engineData->engine(productName) = "MCDiscreteArithmeticAPEngine";
+        engineData->engineParameters(productName) = {{"ProcessType", "Discrete"},    {"BrownianBridge", "True"},
+                                                     {"AntitheticVariate", "False"}, {"ControlVariate", "True"},
+                                                     {"RequiredSamples", "2047"},   {"Seed", "0"}};
+        engineFactory = boost::make_shared<EngineFactory>(engineData, market);
+
+        // Set evaluation date
+        Settings::instance().evaluationDate() = market->asofDate();
+        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, fixingDates);
+
+        // Test the building of a commodity Asian option doesn't throw
+        OptionData optionData("Long", to_string(a.type), "European", true, {to_string(expiry)}, "Cash", "", 0.0, "", "",
+                              vector<Real>(), vector<Real>(), "", "", "", vector<string>(), vector<string>(), "", "",
+                              "", "Asian", boost::none, boost::none, boost::none, asianData);
+
+        boost::shared_ptr<CommodityAsianOption> asianOption =
+            boost::make_shared<CommodityAsianOption>(env, optionData, "ALU_USD", "USD", a.strike, 1, false);
+        BOOST_CHECK_NO_THROW(asianOption->build(engineFactory));
+
+        // Check the underlying instrument was built as expected
+        boost::shared_ptr<Instrument> qlInstrument = asianOption->instrument()->qlInstrument();
+
+        boost::shared_ptr<DiscreteAveragingAsianOption> discreteAsian =
+            boost::dynamic_pointer_cast<DiscreteAveragingAsianOption>(qlInstrument);
+
+        BOOST_CHECK(discreteAsian);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->type(), Exercise::Type::European);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates().size(), 1);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates()[0], expiry);
+
+        boost::shared_ptr<TypePayoff> payoff = boost::dynamic_pointer_cast<TypePayoff>(discreteAsian->payoff());
+        BOOST_CHECK(payoff);
+        BOOST_CHECK_EQUAL(payoff->optionType(), a.type);
+
+        Real expectedPrice = a.expectedNPV;
+
+        // Check the price
+        BOOST_CHECK_SMALL(asianOption->instrument()->NPV() - expectedPrice, 2e-2);
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(testCommodityAsianOptionFromXml) {
+
+    BOOST_TEST_MESSAGE("Testing parsing of commodity Asian option trade from XML");
+
+    // Create an XML string representation of the trade
+    string tradeXml;
+    tradeXml.append("<Portfolio>");
+    tradeXml.append("  <Trade id=\"CommodityAsianOption_Alu\">");
+    tradeXml.append("    <TradeType>CommodityAsianOption</TradeType>");
+    tradeXml.append("    <Envelope>");
+    tradeXml.append("      <CounterParty>CPTY_A</CounterParty>");
+    tradeXml.append("      <NettingSetId>CPTY_A</NettingSetId>");
+    tradeXml.append("      <AdditionalFields/>");
+    tradeXml.append("    </Envelope>");
+    tradeXml.append("    <CommodityAsianOptionData>");
+    tradeXml.append("      <OptionData>");
+    tradeXml.append("        <LongShort>Long</LongShort>");
+    tradeXml.append("        <OptionType>Call</OptionType>");
+    tradeXml.append("        <Style>European</Style>");
+    tradeXml.append("        <Settlement>Cash</Settlement>");
+    tradeXml.append("        <PayOffAtExpiry>false</PayOffAtExpiry>");
+    tradeXml.append("        <PayoffType>Asian</PayoffType>");
+    tradeXml.append("        <ExerciseDates>");
+    tradeXml.append("          <ExerciseDate>2021-02-26</ExerciseDate>");
+    tradeXml.append("        </ExerciseDates>");
+    tradeXml.append("        <AsianData>");
+    tradeXml.append("          <AsianType>Price</AsianType>");
+    tradeXml.append("          <AverageType>Arithmetic</AverageType>");
+    tradeXml.append("          <FixingDates>");
+    tradeXml.append("            <FixingDate>2021-02-01</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-02</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-03</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-04</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-05</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-08</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-09</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-10</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-11</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-12</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-15</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-16</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-17</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-18</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-19</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-22</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-23</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-24</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-25</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-26</FixingDate>");
+    tradeXml.append("          </FixingDates>");
+    tradeXml.append("        </AsianData>");
+    tradeXml.append("      </OptionData>");
+    tradeXml.append("      <Name>ALU_USD</Name>");
+    tradeXml.append("      <IsFuturePrice>false</IsFuturePrice>");
+    tradeXml.append("      <Currency>USD</Currency>");
+    tradeXml.append("      <Strike>2270</Strike>");
+    tradeXml.append("      <Quantity>1</Quantity>");
+    tradeXml.append("    </CommodityAsianOptionData>");
+    tradeXml.append("  </Trade>");
+    tradeXml.append("</Portfolio>");
+
+    // Load portfolio from XML string
+    Portfolio portfolio;
+    portfolio.loadFromXMLString(tradeXml);
+
+    // Extract CommodityAsianOption trade from portfolio
+    boost::shared_ptr<Trade> trade = portfolio.trades()[0];
+    boost::shared_ptr<CommodityAsianOption> option =
+        boost::dynamic_pointer_cast<ore::data::CommodityAsianOption>(trade);
+
+    // Check fields after checking that the cast was successful
+    BOOST_CHECK(option);
+    BOOST_CHECK_EQUAL(option->tradeType(), "CommodityAsianOption");
+    BOOST_CHECK_EQUAL(option->id(), "CommodityAsianOption_Alu");
+    BOOST_CHECK_EQUAL(option->asset(), "ALU_USD");
+    BOOST_CHECK_EQUAL(option->currency(), "USD");
+    BOOST_CHECK_EQUAL(option->strike(), 2270);
+    BOOST_CHECK_EQUAL(option->quantity(), 1);
+    BOOST_CHECK_EQUAL(option->option().longShort(), "Long");
+    BOOST_CHECK_EQUAL(option->option().callPut(), "Call");
+    BOOST_CHECK_EQUAL(option->option().style(), "European");
+    BOOST_CHECK_EQUAL(option->option().exerciseDates().size(), 1);
+    BOOST_CHECK_EQUAL(option->option().exerciseDates()[0], "2021-02-26");
+
+    BOOST_REQUIRE(option->option().asianData());
+    OptionAsianData oad = *option->option().asianData();
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
+    // Checking first and last dates only - full coverage tested in OREDataTestSuite/optionasiandata.cpp
+    BOOST_CHECK_EQUAL(oad.fixingDates().front(), Date(01, Feb, 2021));
+    BOOST_CHECK_EQUAL(oad.fixingDates().back(), Date(26, Feb, 2021));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/commodityasianoption.cpp
+++ b/OREData/test/commodityasianoption.cpp
@@ -142,10 +142,15 @@ BOOST_AUTO_TEST_CASE(testCommodityAsianOptionTradeBuilding) {
         Time deltaT = a.length / (a.fixings - 1);
         Date expiry;
         vector<Date> fixingDates(a.fixings);
+        vector<std::string> strFixingDates(a.fixings);
         for (Size i = 0; i < a.fixings; ++i) {
             fixingDates[i] = (asof + static_cast<Integer>((a.firstFixing + i * deltaT) * 360 + 0.5));
+            strFixingDates[i] = to_string(fixingDates[i]);
         }
         expiry = fixingDates[a.fixings - 1];
+
+        ScheduleDates scheduleDates("NullCalendar", "", "", strFixingDates);
+        ScheduleData scheduleData(scheduleDates);
 
         market = boost::make_shared<TestMarket>(a.spot, expiry, a.riskFreeRate, a.convenienceYield, a.volatility);
         boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
@@ -154,20 +159,20 @@ BOOST_AUTO_TEST_CASE(testCommodityAsianOptionTradeBuilding) {
         engineData->engine(productName) = "MCDiscreteArithmeticAPEngine";
         engineData->engineParameters(productName) = {{"ProcessType", "Discrete"},    {"BrownianBridge", "True"},
                                                      {"AntitheticVariate", "False"}, {"ControlVariate", "True"},
-                                                     {"RequiredSamples", "2047"},   {"Seed", "0"}};
+                                                     {"RequiredSamples", "2047"},    {"Seed", "0"}};
         engineFactory = boost::make_shared<EngineFactory>(engineData, market);
 
         // Set evaluation date
         Settings::instance().evaluationDate() = market->asofDate();
-        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, fixingDates);
+        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic);
 
         // Test the building of a commodity Asian option doesn't throw
         OptionData optionData("Long", to_string(a.type), "European", true, {to_string(expiry)}, "Cash", "", 0.0, "", "",
                               vector<Real>(), vector<Real>(), "", "", "", vector<string>(), vector<string>(), "", "",
-                              "", "Asian", boost::none, boost::none, boost::none, asianData);
+                              "", "Asian", boost::none, boost::none, boost::none);
 
-        boost::shared_ptr<CommodityAsianOption> asianOption =
-            boost::make_shared<CommodityAsianOption>(env, optionData, "ALU_USD", "USD", a.strike, 1, false);
+        boost::shared_ptr<CommodityAsianOption> asianOption = boost::make_shared<CommodityAsianOption>(
+            env, optionData, asianData, scheduleData, "ALU_USD", "USD", a.strike, 1, false);
         BOOST_CHECK_NO_THROW(asianOption->build(engineFactory));
 
         // Check the underlying instrument was built as expected
@@ -218,33 +223,37 @@ BOOST_AUTO_TEST_CASE(testCommodityAsianOptionFromXml) {
     tradeXml.append("        <ExerciseDates>");
     tradeXml.append("          <ExerciseDate>2021-02-26</ExerciseDate>");
     tradeXml.append("        </ExerciseDates>");
-    tradeXml.append("        <AsianData>");
-    tradeXml.append("          <AsianType>Price</AsianType>");
-    tradeXml.append("          <AverageType>Arithmetic</AverageType>");
-    tradeXml.append("          <FixingDates>");
-    tradeXml.append("            <FixingDate>2021-02-01</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-02</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-03</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-04</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-05</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-08</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-09</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-10</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-11</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-12</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-15</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-16</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-17</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-18</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-19</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-22</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-23</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-24</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-25</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-26</FixingDate>");
-    tradeXml.append("          </FixingDates>");
-    tradeXml.append("        </AsianData>");
     tradeXml.append("      </OptionData>");
+    tradeXml.append("      <AsianData>");
+    tradeXml.append("        <AsianType>Price</AsianType>");
+    tradeXml.append("        <AverageType>Arithmetic</AverageType>");
+    tradeXml.append("      </AsianData>");
+    tradeXml.append("      <ScheduleData>");
+    tradeXml.append("        <Dates>");
+    tradeXml.append("          <Dates>");
+    tradeXml.append("            <Date>2021-02-01</Date>");
+    tradeXml.append("            <Date>2021-02-02</Date>");
+    tradeXml.append("            <Date>2021-02-03</Date>");
+    tradeXml.append("            <Date>2021-02-04</Date>");
+    tradeXml.append("            <Date>2021-02-05</Date>");
+    tradeXml.append("            <Date>2021-02-08</Date>");
+    tradeXml.append("            <Date>2021-02-09</Date>");
+    tradeXml.append("            <Date>2021-02-10</Date>");
+    tradeXml.append("            <Date>2021-02-11</Date>");
+    tradeXml.append("            <Date>2021-02-12</Date>");
+    tradeXml.append("            <Date>2021-02-15</Date>");
+    tradeXml.append("            <Date>2021-02-16</Date>");
+    tradeXml.append("            <Date>2021-02-17</Date>");
+    tradeXml.append("            <Date>2021-02-18</Date>");
+    tradeXml.append("            <Date>2021-02-19</Date>");
+    tradeXml.append("            <Date>2021-02-22</Date>");
+    tradeXml.append("            <Date>2021-02-23</Date>");
+    tradeXml.append("            <Date>2021-02-24</Date>");
+    tradeXml.append("            <Date>2021-02-25</Date>");
+    tradeXml.append("            <Date>2021-02-26</Date>");
+    tradeXml.append("          </Dates>");
+    tradeXml.append("        </Dates>");
+    tradeXml.append("      </ScheduleData>");
     tradeXml.append("      <Name>ALU_USD</Name>");
     tradeXml.append("      <IsFuturePrice>false</IsFuturePrice>");
     tradeXml.append("      <Currency>USD</Currency>");
@@ -276,14 +285,11 @@ BOOST_AUTO_TEST_CASE(testCommodityAsianOptionFromXml) {
     BOOST_CHECK_EQUAL(option->option().style(), "European");
     BOOST_CHECK_EQUAL(option->option().exerciseDates().size(), 1);
     BOOST_CHECK_EQUAL(option->option().exerciseDates()[0], "2021-02-26");
+    BOOST_CHECK(option->scheduleData().hasData());
 
-    BOOST_REQUIRE(option->option().asianData());
-    OptionAsianData oad = *option->option().asianData();
+    OptionAsianData oad = option->asianData();
     BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
     BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
-    // Checking first and last dates only - full coverage tested in OREDataTestSuite/optionasiandata.cpp
-    BOOST_CHECK_EQUAL(oad.fixingDates().front(), Date(01, Feb, 2021));
-    BOOST_CHECK_EQUAL(oad.fixingDates().back(), Date(26, Feb, 2021));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/equityasianoption.cpp
+++ b/OREData/test/equityasianoption.cpp
@@ -1,0 +1,281 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <oret/toplevelfixture.hpp>
+
+#include <boost/make_shared.hpp>
+
+#include <ql/currencies/america.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+
+#include <ored/marketdata/marketimpl.hpp>
+#include <ored/portfolio/builders/equityasianoption.hpp>
+#include <ored/portfolio/equityasianoption.hpp>
+#include <ored/portfolio/portfolio.hpp>
+#include <ored/utilities/to_string.hpp>
+
+using namespace std;
+using namespace boost::unit_test_framework;
+using namespace boost::algorithm;
+using namespace QuantLib;
+using namespace QuantExt;
+using namespace ore::data;
+
+namespace {
+
+class TestMarket : public MarketImpl {
+public:
+    TestMarket(const Real spot, const Date& expiry, const Rate riskFreeRate, const Rate dividendYield,
+               const Volatility flatVolatility) {
+        // Reference date and common day counter
+        asof_ = Date(01, Feb, 2021);
+        // Actual365Fixed dayCounter;
+        DayCounter dayCounter = Actual360();
+
+        // Add USD discount curve
+        Handle<YieldTermStructure> discount(boost::make_shared<FlatForward>(asof_, riskFreeRate, dayCounter));
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::Discount, "USD")] = discount;
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::Yield, "COMPANY")] = discount;
+
+        // Add COMPANY dividend yield
+        Handle<YieldTermStructure> dividendYTS(boost::make_shared<FlatForward>(asof_, dividendYield, dayCounter));
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::EquityDividend, "COMPANY")] = dividendYTS;
+
+        // Add equity spots
+        equitySpots_[make_pair(Market::defaultConfiguration, "COMPANY")] =
+            Handle<Quote>(boost::make_shared<SimpleQuote>(spot));
+
+        // Add COMPANY equity curve
+        equityCurves_[make_pair(Market::defaultConfiguration, "COMPANY")] = Handle<EquityIndex>(
+            boost::make_shared<EquityIndex>("COMPANY", TARGET(), parseCurrency("USD"), equitySpot("COMPANY"),
+                                            yieldCurve(YieldCurveType::Discount, "USD"),
+                                            yieldCurve(YieldCurveType::EquityDividend, "COMPANY")));
+
+        // Add COMPANY volatilities
+        Handle<BlackVolTermStructure> volatility(
+            boost::make_shared<BlackConstantVol>(asof_, TARGET(), flatVolatility, dayCounter));
+        equityVols_[make_pair(Market::defaultConfiguration, "COMPANY")] = volatility;
+    }
+};
+
+struct DiscreteAsianTestData {
+    Option::Type type;
+    Real spot;
+    Real strike;
+    Rate dividendYield;
+    Rate riskFreeRate;
+    Time firstFixing;
+    Time length;
+    Size fixings;
+    Volatility volatility;
+    Real expectedNPV;
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(OREDataTestSuite, ore::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(EquityAsianOptionTests)
+
+BOOST_AUTO_TEST_CASE(testEquityAsianOptionTradeBuilding) {
+
+    BOOST_TEST_MESSAGE("Testing equity Asian option trade building with constant vol term structure");
+
+    // Data from "Asian Option", Levy, 1997 in "Exotic Options: The State of the Art",
+    // edited by Clewlow, Strickland
+    // Tests with > 100 fixings are skipped here for speed, QL already tests these
+    std::vector<DiscreteAsianTestData> asians = {
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 2, 0.13, 1.3942835683},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 4, 0.13, 1.5852442983},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 8, 0.13, 1.66970673},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 12, 0.13, 1.6980019214},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 26, 0.13, 1.7255070456},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 52, 0.13, 1.7401553533},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 100, 0.13, 1.7478303712},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 2, 0.13, 1.8496053697},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.0111495205},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.0852138818},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.1105094397},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.1346526695},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.147489651},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.154728109},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 2, 0.13, 2.63315092584},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.76723962361},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.83124836881},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.84290301412},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.88179560417},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.88447044543},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.89985329603}};
+
+    Date asof = Date(01, Feb, 2021);
+    Envelope env("CP1");
+    boost::shared_ptr<EngineFactory> engineFactory;
+    boost::shared_ptr<Market> market;
+
+    for (const auto& a : asians) {
+        Time deltaT = a.length / (a.fixings - 1);
+        Date expiry;
+        vector<Date> fixingDates(a.fixings);
+        for (Size i = 0; i < a.fixings; ++i) {
+            fixingDates[i] = (asof + static_cast<Integer>((a.firstFixing + i * deltaT) * 360 + 0.5));
+        }
+        expiry = fixingDates[a.fixings - 1];
+
+        market = boost::make_shared<TestMarket>(a.spot, expiry, a.riskFreeRate, a.dividendYield, a.volatility);
+        boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
+        std::string productName = "EquityAsianOptionArithmeticPrice";
+        engineData->model(productName) = "BlackScholesMerton";
+        engineData->engine(productName) = "MCDiscreteArithmeticAPEngine";
+        engineData->engineParameters(productName) = {{"ProcessType", "Discrete"},    {"BrownianBridge", "True"},
+                                                     {"AntitheticVariate", "False"}, {"ControlVariate", "True"},
+                                                     {"RequiredSamples", "2047"},    {"Seed", "0"}};
+        engineFactory = boost::make_shared<EngineFactory>(engineData, market);
+
+        // Set evaluation date
+        Settings::instance().evaluationDate() = market->asofDate();
+        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, fixingDates);
+
+        // Test the building of a equity Asian option doesn't throw
+        OptionData optionData("Long", to_string(a.type), "European", true, {to_string(expiry)}, "Cash", "", 0.0, "", "",
+                              vector<Real>(), vector<Real>(), "", "", "", vector<string>(), vector<string>(), "", "",
+                              "", "Asian", boost::none, boost::none, boost::none, asianData);
+
+        boost::shared_ptr<EquityAsianOption> asianOption =
+            boost::make_shared<EquityAsianOption>(env, optionData, EquityUnderlying("COMPANY"), "USD", a.strike, 1);
+        BOOST_CHECK_NO_THROW(asianOption->build(engineFactory));
+
+        // Check the underlying instrument was built as expected
+        boost::shared_ptr<Instrument> qlInstrument = asianOption->instrument()->qlInstrument();
+
+        boost::shared_ptr<DiscreteAveragingAsianOption> discreteAsian =
+            boost::dynamic_pointer_cast<DiscreteAveragingAsianOption>(qlInstrument);
+
+        BOOST_CHECK(discreteAsian);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->type(), Exercise::Type::European);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates().size(), 1);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates()[0], expiry);
+
+        boost::shared_ptr<TypePayoff> payoff = boost::dynamic_pointer_cast<TypePayoff>(discreteAsian->payoff());
+        BOOST_CHECK(payoff);
+        BOOST_CHECK_EQUAL(payoff->optionType(), a.type);
+
+        Real expectedPrice = a.expectedNPV;
+
+        // Check the price
+        BOOST_CHECK_SMALL(asianOption->instrument()->NPV() - expectedPrice, 2e-2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testEquityAsianOptionFromXml) {
+
+    BOOST_TEST_MESSAGE("Testing parsing of equity Asian option trade from XML");
+
+    // Create an XML string representation of the trade
+    string tradeXml;
+    tradeXml.append("<Portfolio>");
+    tradeXml.append("  <Trade id=\"EquityAsianOption_Company\">");
+    tradeXml.append("    <TradeType>EquityAsianOption</TradeType>");
+    tradeXml.append("    <Envelope>");
+    tradeXml.append("      <CounterParty>CPTY_A</CounterParty>");
+    tradeXml.append("      <NettingSetId>CPTY_A</NettingSetId>");
+    tradeXml.append("      <AdditionalFields/>");
+    tradeXml.append("    </Envelope>");
+    tradeXml.append("    <EquityAsianOptionData>");
+    tradeXml.append("      <OptionData>");
+    tradeXml.append("        <LongShort>Long</LongShort>");
+    tradeXml.append("        <OptionType>Call</OptionType>");
+    tradeXml.append("        <Style>European</Style>");
+    tradeXml.append("        <Settlement>Cash</Settlement>");
+    tradeXml.append("        <PayOffAtExpiry>false</PayOffAtExpiry>");
+    tradeXml.append("        <PayoffType>Asian</PayoffType>");
+    tradeXml.append("        <ExerciseDates>");
+    tradeXml.append("          <ExerciseDate>2021-02-26</ExerciseDate>");
+    tradeXml.append("        </ExerciseDates>");
+    tradeXml.append("        <AsianData>");
+    tradeXml.append("          <AsianType>Price</AsianType>");
+    tradeXml.append("          <AverageType>Arithmetic</AverageType>");
+    tradeXml.append("          <FixingDates>");
+    tradeXml.append("            <FixingDate>2021-02-01</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-02</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-03</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-04</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-05</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-08</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-09</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-10</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-11</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-12</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-15</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-16</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-17</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-18</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-19</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-22</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-23</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-24</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-25</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-26</FixingDate>");
+    tradeXml.append("          </FixingDates>");
+    tradeXml.append("        </AsianData>");
+    tradeXml.append("      </OptionData>");
+    tradeXml.append("      <Name>COMPANY</Name>");
+    tradeXml.append("      <Currency>USD</Currency>");
+    tradeXml.append("      <Strike>2270</Strike>");
+    tradeXml.append("      <Quantity>1</Quantity>");
+    tradeXml.append("    </EquityAsianOptionData>");
+    tradeXml.append("  </Trade>");
+    tradeXml.append("</Portfolio>");
+
+    // Load portfolio from XML string
+    Portfolio portfolio;
+    portfolio.loadFromXMLString(tradeXml);
+
+    // Extract EquityAsianOption trade from portfolio
+    boost::shared_ptr<Trade> trade = portfolio.trades()[0];
+    boost::shared_ptr<EquityAsianOption> option = boost::dynamic_pointer_cast<ore::data::EquityAsianOption>(trade);
+
+    // Check fields after checking that the cast was successful
+    BOOST_CHECK(option);
+    BOOST_CHECK_EQUAL(option->tradeType(), "EquityAsianOption");
+    BOOST_CHECK_EQUAL(option->id(), "EquityAsianOption_Company");
+    BOOST_CHECK_EQUAL(option->equityName(), "COMPANY");
+    BOOST_CHECK_EQUAL(option->currency(), "USD");
+    BOOST_CHECK_EQUAL(option->strike(), 2270);
+    BOOST_CHECK_EQUAL(option->quantity(), 1);
+    BOOST_CHECK_EQUAL(option->option().longShort(), "Long");
+    BOOST_CHECK_EQUAL(option->option().callPut(), "Call");
+    BOOST_CHECK_EQUAL(option->option().style(), "European");
+    BOOST_CHECK_EQUAL(option->option().exerciseDates().size(), 1);
+    BOOST_CHECK_EQUAL(option->option().exerciseDates()[0], "2021-02-26");
+
+    BOOST_REQUIRE(option->option().asianData());
+    OptionAsianData oad = *option->option().asianData();
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
+    // Checking first and last dates only - full coverage tested in OREDataTestSuite/optionasiandata.cpp
+    BOOST_CHECK_EQUAL(oad.fixingDates().front(), Date(01, Feb, 2021));
+    BOOST_CHECK_EQUAL(oad.fixingDates().back(), Date(26, Feb, 2021));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/fxasianoption.cpp
+++ b/OREData/test/fxasianoption.cpp
@@ -124,10 +124,15 @@ BOOST_AUTO_TEST_CASE(testFxAsianOptionTradeBuilding) {
         Time deltaT = a.length / (a.fixings - 1);
         Date expiry;
         vector<Date> fixingDates(a.fixings);
+        vector<std::string> strFixingDates(a.fixings);
         for (Size i = 0; i < a.fixings; ++i) {
             fixingDates[i] = (asof + static_cast<Integer>((a.firstFixing + i * deltaT) * 360 + 0.5));
+            strFixingDates[i] = to_string(fixingDates[i]);
         }
         expiry = fixingDates[a.fixings - 1];
+
+        ScheduleDates scheduleDates("NullCalendar", "", "", strFixingDates);
+        ScheduleData scheduleData(scheduleDates);
 
         market = boost::make_shared<TestMarket>(a.spot, expiry, a.domesticRate, a.foreignRate, a.volatility);
         boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
@@ -141,15 +146,15 @@ BOOST_AUTO_TEST_CASE(testFxAsianOptionTradeBuilding) {
 
         // Set evaluation date
         Settings::instance().evaluationDate() = market->asofDate();
-        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, fixingDates);
+        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic);
 
         // Test the building of a FX Asian option doesn't throw
         OptionData optionData("Long", to_string(a.type), "European", true, {to_string(expiry)}, "Cash", "", 0.0, "", "",
                               vector<Real>(), vector<Real>(), "", "", "", vector<string>(), vector<string>(), "", "",
-                              "", "Asian", boost::none, boost::none, boost::none, asianData);
+                              "", "Asian", boost::none, boost::none, boost::none);
 
-        boost::shared_ptr<FxAsianOption> asianOption =
-            boost::make_shared<FxAsianOption>(env, optionData, "JPY", 1, "USD", a.strike, "FX-ECB-JPY-USD");
+        boost::shared_ptr<FxAsianOption> asianOption = boost::make_shared<FxAsianOption>(
+            env, optionData, asianData, scheduleData, "JPY", 1, "USD", a.strike, "FX-ECB-JPY-USD");
         BOOST_CHECK_NO_THROW(asianOption->build(engineFactory));
 
         // Check the underlying instrument was built as expected
@@ -199,33 +204,37 @@ BOOST_AUTO_TEST_CASE(testFxAsianOptionFromXml) {
     tradeXml.append("        <ExerciseDates>");
     tradeXml.append("          <ExerciseDate>2021-02-26</ExerciseDate>");
     tradeXml.append("        </ExerciseDates>");
-    tradeXml.append("        <AsianData>");
-    tradeXml.append("          <AsianType>Price</AsianType>");
-    tradeXml.append("          <AverageType>Arithmetic</AverageType>");
-    tradeXml.append("          <FixingDates>");
-    tradeXml.append("            <FixingDate>2021-02-01</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-02</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-03</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-04</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-05</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-08</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-09</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-10</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-11</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-12</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-15</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-16</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-17</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-18</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-19</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-22</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-23</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-24</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-25</FixingDate>");
-    tradeXml.append("            <FixingDate>2021-02-26</FixingDate>");
-    tradeXml.append("          </FixingDates>");
-    tradeXml.append("        </AsianData>");
     tradeXml.append("      </OptionData>");
+    tradeXml.append("      <AsianData>");
+    tradeXml.append("        <AsianType>Price</AsianType>");
+    tradeXml.append("        <AverageType>Arithmetic</AverageType>");
+    tradeXml.append("      </AsianData>");
+    tradeXml.append("      <ScheduleData>");
+    tradeXml.append("        <Dates>");
+    tradeXml.append("          <Dates>");
+    tradeXml.append("            <Date>2021-02-01</Date>");
+    tradeXml.append("            <Date>2021-02-02</Date>");
+    tradeXml.append("            <Date>2021-02-03</Date>");
+    tradeXml.append("            <Date>2021-02-04</Date>");
+    tradeXml.append("            <Date>2021-02-05</Date>");
+    tradeXml.append("            <Date>2021-02-08</Date>");
+    tradeXml.append("            <Date>2021-02-09</Date>");
+    tradeXml.append("            <Date>2021-02-10</Date>");
+    tradeXml.append("            <Date>2021-02-11</Date>");
+    tradeXml.append("            <Date>2021-02-12</Date>");
+    tradeXml.append("            <Date>2021-02-15</Date>");
+    tradeXml.append("            <Date>2021-02-16</Date>");
+    tradeXml.append("            <Date>2021-02-17</Date>");
+    tradeXml.append("            <Date>2021-02-18</Date>");
+    tradeXml.append("            <Date>2021-02-19</Date>");
+    tradeXml.append("            <Date>2021-02-22</Date>");
+    tradeXml.append("            <Date>2021-02-23</Date>");
+    tradeXml.append("            <Date>2021-02-24</Date>");
+    tradeXml.append("            <Date>2021-02-25</Date>");
+    tradeXml.append("            <Date>2021-02-26</Date>");
+    tradeXml.append("          </Dates>");
+    tradeXml.append("        </Dates>");
+    tradeXml.append("      </ScheduleData>");
     tradeXml.append("      <BoughtCurrency>USD</BoughtCurrency>");
     tradeXml.append("      <SoldCurrency>JPY</SoldCurrency>");
     tradeXml.append("      <BoughtAmount>1</BoughtAmount>");
@@ -258,14 +267,11 @@ BOOST_AUTO_TEST_CASE(testFxAsianOptionFromXml) {
     BOOST_CHECK_EQUAL(option->option().style(), "European");
     BOOST_CHECK_EQUAL(option->option().exerciseDates().size(), 1);
     BOOST_CHECK_EQUAL(option->option().exerciseDates()[0], "2021-02-26");
+    BOOST_CHECK(option->scheduleData().hasData());
 
-    BOOST_REQUIRE(option->option().asianData());
-    OptionAsianData oad = *option->option().asianData();
+    OptionAsianData oad = option->asianData();
     BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
     BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
-    // Checking first and last dates only - full coverage tested in OREDataTestSuite/optionasiandata.cpp
-    BOOST_CHECK_EQUAL(oad.fixingDates().front(), Date(01, Feb, 2021));
-    BOOST_CHECK_EQUAL(oad.fixingDates().back(), Date(26, Feb, 2021));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/fxasianoption.cpp
+++ b/OREData/test/fxasianoption.cpp
@@ -1,0 +1,273 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <oret/toplevelfixture.hpp>
+
+#include <boost/make_shared.hpp>
+
+#include <ql/currencies/america.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+
+#include <ored/marketdata/marketimpl.hpp>
+#include <ored/portfolio/builders/fxasianoption.hpp>
+#include <ored/portfolio/fxasianoption.hpp>
+#include <ored/portfolio/portfolio.hpp>
+#include <ored/utilities/to_string.hpp>
+
+using namespace std;
+using namespace boost::unit_test_framework;
+using namespace boost::algorithm;
+using namespace QuantLib;
+using namespace QuantExt;
+using namespace ore::data;
+
+namespace {
+
+class TestMarket : public MarketImpl {
+public:
+    TestMarket(const Real spot, const Date& expiry, const Rate domRate, const Rate forRate,
+               const Volatility flatVolatility) {
+        // Reference date and common day counter
+        asof_ = Date(01, Feb, 2021);
+        DayCounter dayCounter = Actual360();
+
+        // Add USD/JPY discount curves
+        Handle<YieldTermStructure> domestic(boost::make_shared<FlatForward>(asof_, domRate, dayCounter));
+        Handle<YieldTermStructure> foreign(boost::make_shared<FlatForward>(asof_, forRate, dayCounter));
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::Discount, "USD")] = domestic;
+        yieldCurves_[make_tuple(Market::defaultConfiguration, YieldCurveType::Discount, "JPY")] = foreign;
+
+        // Add fx spot
+        fxSpots_[Market::defaultConfiguration].addQuote("JPYUSD", Handle<Quote>(boost::make_shared<SimpleQuote>(spot)));
+
+        // Add USDJPY volatilities
+        Handle<BlackVolTermStructure> volatility(
+            boost::make_shared<BlackConstantVol>(asof_, TARGET(), flatVolatility, dayCounter));
+        fxVols_[make_pair(Market::defaultConfiguration, "JPYUSD")] = volatility;
+    }
+};
+
+struct DiscreteAsianTestData {
+    Option::Type type;
+    Real spot;
+    Real strike;
+    Rate foreignRate;
+    Rate domesticRate;
+    Time firstFixing;
+    Time length;
+    Size fixings;
+    Volatility volatility;
+    Real expectedNPV;
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(OREDataTestSuite, ore::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(FxAsianOptionTests)
+
+BOOST_AUTO_TEST_CASE(testFxAsianOptionTradeBuilding) {
+
+    BOOST_TEST_MESSAGE("Testing FX Asian option trade building with constant vol term structure");
+
+    // Data from "Asian Option", Levy, 1997 in "Exotic Options: The State of the Art",
+    // edited by Clewlow, Strickland
+    // Tests with > 100 fixings are skipped here for speed, QL already tests these
+    std::vector<DiscreteAsianTestData> asians = {
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 2, 0.13, 1.3942835683},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 4, 0.13, 1.5852442983},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 8, 0.13, 1.66970673},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 12, 0.13, 1.6980019214},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 26, 0.13, 1.7255070456},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 52, 0.13, 1.7401553533},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 0.0, 11.0 / 12.0, 100, 0.13, 1.7478303712},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 2, 0.13, 1.8496053697},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.0111495205},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.0852138818},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.1105094397},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.1346526695},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.147489651},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 1.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.154728109},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 2, 0.13, 2.63315092584},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 4, 0.13, 2.76723962361},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 8, 0.13, 2.83124836881},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 12, 0.13, 2.84290301412},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 26, 0.13, 2.88179560417},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 52, 0.13, 2.88447044543},
+        {Option::Put, 90.0, 87.0, 0.06, 0.025, 3.0 / 12.0, 11.0 / 12.0, 100, 0.13, 2.89985329603}};
+
+    Date asof = Date(01, Feb, 2021);
+    Envelope env("CP1");
+    boost::shared_ptr<EngineFactory> engineFactory;
+    boost::shared_ptr<Market> market;
+
+    for (const auto& a : asians) {
+        Time deltaT = a.length / (a.fixings - 1);
+        Date expiry;
+        vector<Date> fixingDates(a.fixings);
+        for (Size i = 0; i < a.fixings; ++i) {
+            fixingDates[i] = (asof + static_cast<Integer>((a.firstFixing + i * deltaT) * 360 + 0.5));
+        }
+        expiry = fixingDates[a.fixings - 1];
+
+        market = boost::make_shared<TestMarket>(a.spot, expiry, a.domesticRate, a.foreignRate, a.volatility);
+        boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
+        std::string productName = "FxAsianOptionArithmeticPrice";
+        engineData->model(productName) = "BlackScholesMerton";
+        engineData->engine(productName) = "MCDiscreteArithmeticAPEngine";
+        engineData->engineParameters(productName) = {{"ProcessType", "Discrete"},    {"BrownianBridge", "True"},
+                                                     {"AntitheticVariate", "False"}, {"ControlVariate", "True"},
+                                                     {"RequiredSamples", "2047"},    {"Seed", "0"}};
+        engineFactory = boost::make_shared<EngineFactory>(engineData, market);
+
+        // Set evaluation date
+        Settings::instance().evaluationDate() = market->asofDate();
+        OptionAsianData asianData(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, fixingDates);
+
+        // Test the building of a FX Asian option doesn't throw
+        OptionData optionData("Long", to_string(a.type), "European", true, {to_string(expiry)}, "Cash", "", 0.0, "", "",
+                              vector<Real>(), vector<Real>(), "", "", "", vector<string>(), vector<string>(), "", "",
+                              "", "Asian", boost::none, boost::none, boost::none, asianData);
+
+        boost::shared_ptr<FxAsianOption> asianOption =
+            boost::make_shared<FxAsianOption>(env, optionData, "JPY", 1, "USD", a.strike, "FX-ECB-JPY-USD");
+        BOOST_CHECK_NO_THROW(asianOption->build(engineFactory));
+
+        // Check the underlying instrument was built as expected
+        boost::shared_ptr<Instrument> qlInstrument = asianOption->instrument()->qlInstrument();
+
+        boost::shared_ptr<DiscreteAveragingAsianOption> discreteAsian =
+            boost::dynamic_pointer_cast<DiscreteAveragingAsianOption>(qlInstrument);
+
+        BOOST_CHECK(discreteAsian);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->type(), Exercise::Type::European);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates().size(), 1);
+        BOOST_CHECK_EQUAL(discreteAsian->exercise()->dates()[0], expiry);
+
+        boost::shared_ptr<TypePayoff> payoff = boost::dynamic_pointer_cast<TypePayoff>(discreteAsian->payoff());
+        BOOST_CHECK(payoff);
+        BOOST_CHECK_EQUAL(payoff->optionType(), a.type);
+
+        Real expectedPrice = a.expectedNPV;
+
+        // Check the price
+        BOOST_CHECK_SMALL(asianOption->instrument()->NPV() - expectedPrice, 2e-2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testFxAsianOptionFromXml) {
+
+    BOOST_TEST_MESSAGE("Testing parsing of FX Asian option trade from XML");
+
+    // Create an XML string representation of the trade
+    string tradeXml;
+    tradeXml.append("<Portfolio>");
+    tradeXml.append("  <Trade id=\"FxAsianOption_USDJPY\">");
+    tradeXml.append("    <TradeType>FxAsianOption</TradeType>");
+    tradeXml.append("    <Envelope>");
+    tradeXml.append("      <CounterParty>CPTY_A</CounterParty>");
+    tradeXml.append("      <NettingSetId>CPTY_A</NettingSetId>");
+    tradeXml.append("      <AdditionalFields/>");
+    tradeXml.append("    </Envelope>");
+    tradeXml.append("    <FxAsianOptionData>");
+    tradeXml.append("      <OptionData>");
+    tradeXml.append("        <LongShort>Long</LongShort>");
+    tradeXml.append("        <OptionType>Call</OptionType>");
+    tradeXml.append("        <Style>European</Style>");
+    tradeXml.append("        <Settlement>Cash</Settlement>");
+    tradeXml.append("        <PayOffAtExpiry>false</PayOffAtExpiry>");
+    tradeXml.append("        <PayoffType>Asian</PayoffType>");
+    tradeXml.append("        <ExerciseDates>");
+    tradeXml.append("          <ExerciseDate>2021-02-26</ExerciseDate>");
+    tradeXml.append("        </ExerciseDates>");
+    tradeXml.append("        <AsianData>");
+    tradeXml.append("          <AsianType>Price</AsianType>");
+    tradeXml.append("          <AverageType>Arithmetic</AverageType>");
+    tradeXml.append("          <FixingDates>");
+    tradeXml.append("            <FixingDate>2021-02-01</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-02</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-03</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-04</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-05</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-08</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-09</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-10</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-11</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-12</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-15</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-16</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-17</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-18</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-19</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-22</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-23</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-24</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-25</FixingDate>");
+    tradeXml.append("            <FixingDate>2021-02-26</FixingDate>");
+    tradeXml.append("          </FixingDates>");
+    tradeXml.append("        </AsianData>");
+    tradeXml.append("      </OptionData>");
+    tradeXml.append("      <BoughtCurrency>USD</BoughtCurrency>");
+    tradeXml.append("      <SoldCurrency>JPY</SoldCurrency>");
+    tradeXml.append("      <BoughtAmount>1</BoughtAmount>");
+    tradeXml.append("      <SoldAmount>104.6860</SoldAmount>");
+    tradeXml.append("      <FXIndex>FX-ECB-USD-JPY</FXIndex>");
+    tradeXml.append("    </FxAsianOptionData>");
+    tradeXml.append("  </Trade>");
+    tradeXml.append("</Portfolio>");
+
+    // Load portfolio from XML string
+    Portfolio portfolio;
+    portfolio.loadFromXMLString(tradeXml);
+
+    // Extract FxAsianOption trade from portfolio
+    boost::shared_ptr<Trade> trade = portfolio.trades()[0];
+    boost::shared_ptr<FxAsianOption> option = boost::dynamic_pointer_cast<ore::data::FxAsianOption>(trade);
+
+    // Check fields after checking that the cast was successful
+    BOOST_CHECK(option);
+    BOOST_CHECK_EQUAL(option->tradeType(), "FxAsianOption");
+    BOOST_CHECK_EQUAL(option->id(), "FxAsianOption_USDJPY");
+    BOOST_CHECK_EQUAL(option->boughtCurrency(), "USD");
+    BOOST_CHECK_EQUAL(option->soldCurrency(), "JPY");
+    BOOST_CHECK_EQUAL(option->boughtAmount(), 1);
+    BOOST_CHECK_EQUAL(option->soldAmount(), 104.6860);
+    BOOST_CHECK_EQUAL(option->strike(), 104.6860);
+    BOOST_CHECK_EQUAL(option->fxIndex(), "FX-ECB-USD-JPY");
+    BOOST_CHECK_EQUAL(option->option().longShort(), "Long");
+    BOOST_CHECK_EQUAL(option->option().callPut(), "Call");
+    BOOST_CHECK_EQUAL(option->option().style(), "European");
+    BOOST_CHECK_EQUAL(option->option().exerciseDates().size(), 1);
+    BOOST_CHECK_EQUAL(option->option().exerciseDates()[0], "2021-02-26");
+
+    BOOST_REQUIRE(option->option().asianData());
+    OptionAsianData oad = *option->option().asianData();
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
+    // Checking first and last dates only - full coverage tested in OREDataTestSuite/optionasiandata.cpp
+    BOOST_CHECK_EQUAL(oad.fixingDates().front(), Date(01, Feb, 2021));
+    BOOST_CHECK_EQUAL(oad.fixingDates().back(), Date(26, Feb, 2021));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/optionasiandata.cpp
+++ b/OREData/test/optionasiandata.cpp
@@ -1,0 +1,118 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <oret/datapaths.hpp>
+#include <oret/toplevelfixture.hpp>
+
+#include <ored/portfolio/optionasiandata.hpp>
+
+using namespace std;
+using namespace boost::unit_test_framework;
+using namespace QuantLib;
+using namespace ore::data;
+
+BOOST_FIXTURE_TEST_SUITE(OREDataTestSuite, ore::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(OptionAsianDataTests)
+
+BOOST_AUTO_TEST_CASE(testOptionAsianDataDefaultConstruction) {
+
+    BOOST_TEST_MESSAGE("Testing default construction...");
+
+    OptionAsianData oad;
+
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
+    BOOST_CHECK_EQUAL(oad.fixingDates().size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(testOptionAsianDataStringConstruction) {
+
+    BOOST_TEST_MESSAGE("Testing construction of OptionAsianData from a vector of string dates...");
+
+    vector<string> strDates{"2021-04-01", "2021-04-30"};
+    OptionAsianData oad(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, strDates);
+
+    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
+    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
+}
+
+BOOST_AUTO_TEST_CASE(testOptionAsianDataDateConstruction) {
+
+    BOOST_TEST_MESSAGE("Testing construction of OptionAsianData from a vector of dates...");
+
+    vector<Date> dates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
+    OptionAsianData oad(OptionAsianData::AsianType::Strike, Average::Type::Geometric, dates);
+
+    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Strike);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Geometric);
+    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
+}
+
+BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionFromXml) {
+
+    BOOST_TEST_MESSAGE("Testing contruction of OptionAsianData from XML...");
+
+    // XML input
+    string xml;
+    xml.append("<AsianData>");
+    xml.append("  <AsianType>Strike</AsianType>");
+    xml.append("  <AverageType>Geometric</AverageType>");
+    xml.append("  <FixingDates>");
+    xml.append("    <FixingDate>2021-04-01</FixingDate>");
+    xml.append("    <FixingDate>2021-04-30</FixingDate>");
+    xml.append("  </FixingDates>");
+    xml.append("</AsianData>");
+
+    // Load OptionPaymentData from XML
+    OptionAsianData oad;
+    oad.fromXMLString(xml);
+
+    // Check is as expected
+    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
+    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Strike);
+    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Geometric);
+    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
+}
+
+BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionToXml) {
+
+    BOOST_TEST_MESSAGE("Testing contruction of OptionAsianData to/from XML...");
+
+    // Construct explicitly
+    vector<Date> dates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
+    OptionAsianData inoad(OptionAsianData::AsianType::Strike, Average::Type::Geometric, dates);
+
+    // Write to XML and read the result from XML to populate new object
+    OptionAsianData outoad;
+    outoad.fromXMLString(inoad.toXMLString());
+
+    // Check is as expected
+    BOOST_CHECK_EQUAL(inoad.asianType(), outoad.asianType());
+    BOOST_CHECK_EQUAL(inoad.averageType(), outoad.averageType());
+    BOOST_CHECK_EQUAL_COLLECTIONS(inoad.fixingDates().begin(), inoad.fixingDates().end(), outoad.fixingDates().begin(),
+                                  outoad.fixingDates().end());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/optionasiandata.cpp
+++ b/OREData/test/optionasiandata.cpp
@@ -39,33 +39,16 @@ BOOST_AUTO_TEST_CASE(testOptionAsianDataDefaultConstruction) {
 
     BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
     BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
-    BOOST_CHECK_EQUAL(oad.fixingDates().size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(testOptionAsianDataStringConstruction) {
 
-    BOOST_TEST_MESSAGE("Testing construction of OptionAsianData from a vector of string dates...");
+    BOOST_TEST_MESSAGE("Testing construction of OptionAsianData...");
 
-    vector<string> strDates{"2021-04-01", "2021-04-30"};
-    OptionAsianData oad(OptionAsianData::AsianType::Price, Average::Type::Arithmetic, strDates);
+    OptionAsianData oad(OptionAsianData::AsianType::Price, Average::Type::Arithmetic);
 
-    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
     BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Price);
     BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Arithmetic);
-    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
-}
-
-BOOST_AUTO_TEST_CASE(testOptionAsianDataDateConstruction) {
-
-    BOOST_TEST_MESSAGE("Testing construction of OptionAsianData from a vector of dates...");
-
-    vector<Date> dates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
-    OptionAsianData oad(OptionAsianData::AsianType::Strike, Average::Type::Geometric, dates);
-
-    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
-    BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Strike);
-    BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Geometric);
-    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
 }
 
 BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionFromXml) {
@@ -77,10 +60,6 @@ BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionFromXml) {
     xml.append("<AsianData>");
     xml.append("  <AsianType>Strike</AsianType>");
     xml.append("  <AverageType>Geometric</AverageType>");
-    xml.append("  <FixingDates>");
-    xml.append("    <FixingDate>2021-04-01</FixingDate>");
-    xml.append("    <FixingDate>2021-04-30</FixingDate>");
-    xml.append("  </FixingDates>");
     xml.append("</AsianData>");
 
     // Load OptionPaymentData from XML
@@ -88,10 +67,8 @@ BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionFromXml) {
     oad.fromXMLString(xml);
 
     // Check is as expected
-    vector<Date> expDates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
     BOOST_CHECK_EQUAL(oad.asianType(), OptionAsianData::AsianType::Strike);
     BOOST_CHECK_EQUAL(oad.averageType(), Average::Type::Geometric);
-    BOOST_CHECK_EQUAL_COLLECTIONS(oad.fixingDates().begin(), oad.fixingDates().end(), expDates.begin(), expDates.end());
 }
 
 BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionToXml) {
@@ -99,8 +76,7 @@ BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionToXml) {
     BOOST_TEST_MESSAGE("Testing contruction of OptionAsianData to/from XML...");
 
     // Construct explicitly
-    vector<Date> dates{Date(01, Apr, 2021), Date(30, Apr, 2021)};
-    OptionAsianData inoad(OptionAsianData::AsianType::Strike, Average::Type::Geometric, dates);
+    OptionAsianData inoad(OptionAsianData::AsianType::Strike, Average::Type::Geometric);
 
     // Write to XML and read the result from XML to populate new object
     OptionAsianData outoad;
@@ -108,9 +84,7 @@ BOOST_AUTO_TEST_CASE(testOptionAsianDataConstructionToXml) {
 
     // Check is as expected
     BOOST_CHECK_EQUAL(inoad.asianType(), outoad.asianType());
-    BOOST_CHECK_EQUAL(inoad.averageType(), outoad.averageType());
-    BOOST_CHECK_EQUAL_COLLECTIONS(inoad.fixingDates().begin(), inoad.fixingDates().end(), outoad.fixingDates().begin(),
-                                  outoad.fixingDates().end());
+    BOOST_CHECK_EQUAL(inoad.averageType(), outoad.averageType());;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Hi, Roland and team!

We're happy to share our perhaps biggest implementation, thus far at least, of Asian options in ORE. In short, we link six QL pricing engines to cover discrete/continuous averaging of arithmetic/geometric average price/strike options. Down below I will try to describe the implementation and any design choices made, before I can get to adding it into the user guide as well. There may well be many questionable choices so I will prematurely give a disclaimer that we have many things to learn still :slightly_smiling_face: A few things still remain to be listed, which I will strive to do shortly, but I will share this as a draft to open up for discussion in the meantime. 

We followed suit from the `VanillaOptionTrade` implementation in OREData and created an `AsianOptionTrade` inheriting directly from Trade. From here, we created three further trade type classes: `EquityAsianOption`, `FxAsianOption`, and `CommodityAsianOption`. We use these as a general interface for both average price and average strike options with a single underlying. The specifics of the trade are added to an `OptionAsianData` class inside `OptionData`, with the properties set in the trade XML as:
```xml
<AsianData>
  <!-- Price/Strike -->
  <AsianType>Price</AsianType>
  <!-- Arithmetic/Geometric -->
  <AverageType>Arithmetic</AverageType>
  <!-- All fixing (i.e. averaging) dates -->
  <FixingDates>
    <FixingDate>2021-02-01</FixingDate>
    …
    <FixingDate>2021-02-26</FixingDate>
  </FixingDates>
</AsianData>
```
Note that we opted to list the "fixing dates" individually rather than having a `<StartDate>` and an `<EndDate>`, in order to avoid calendars and such when generating daily/weekly/monthly fixing schedules. I noted this difference in a portfolio set from a project we had previously purchased, though I suppose both alternatives could be implemented in parallell. 

Documentation: Will add descriptions of the trade types to the user guide files, soon. 

Tests: Includes test coverage of the following bits.
- OptionAsianData contructors and inspectors.
- QL::Average::Type string parser
- EquityAsianOption versus literature
- FxAsianOption versus literature
- CommodityAsianOption versus literature
	
Remarks: 
- QL v1.22 added some improved interfaces for Asian options that I would have liked to utilize, however I've delayed doing this currently as I am using an older version of QL (1.18~). 
- We wrap the instrument with the `VanillaInstrument` class even though the class' comments suggests to use some form of an exotic instrument wrapper. As we have only been interested in PVs, we opted to ignore this and sneakily wrapped the Asian instruments with the vanilla wrapper.
- We left the decision of toggling between discrete/continuous averaging to the _pricingengine.xml_ file. Each engine implemented very awkwardly needs to denote if it assumes Continuous or Discrete process type, to determine whether a `DiscreteAveragingAsianOption` or `ContinuousAveragingAsianOption` instrument should be wrapped.
- We've predominantly ran commodity and equity arithmetic average price trades and thus can attest to them working seemingly correct. The FX variant runs fine in tests, at least. As for average (floating) strike options we haven't verified anything other than the parsing, but I assume these could be easily validated with the Asian parity if I'm not mistaken.
- QuantExt holds some items related to APOs (Turnbull-Wakeman/MC engines) but I opted away from these for now - perhaps someone with better insight can share some thoughts on the potential use of those. 


Best regards,
Fredrik Gerdin Börjesson,
SEB
