### PR TITLE
Grid change for AmericanOptionFDEngineBuilder

### DIFF
--- a/Examples/Input/pricingengine.xml
+++ b/Examples/Input/pricingengine.xml
@@ -33,6 +33,8 @@
       <Parameter name="TimeGridPerYear">100</Parameter>
       <Parameter name="XGrid">100</Parameter>
       <Parameter name="DampingSteps">0</Parameter>
+      <!-- Optional, prevents too small time grids for increased Greek precision when expiry is near -->
+      <!-- <Parameter name="TGridMinimum">20</Parameter> -->
     </EngineParameters>
   </Product>
   <Product type="EuropeanSwaption">
@@ -131,6 +133,8 @@
       <Parameter name="TimeGridPerYear">100</Parameter>
       <Parameter name="XGrid">100</Parameter>
       <Parameter name="DampingSteps">0</Parameter>
+      <!-- Optional, prevents too small time grids for increased Greek precision when expiry is near -->
+      <!-- <Parameter name="TGridMinimum">20</Parameter> -->
     </EngineParameters>
   </Product>
   <Product type="Bond">

--- a/OREData/ored/portfolio/builders/vanillaoption.hpp
+++ b/OREData/ored/portfolio/builders/vanillaoption.hpp
@@ -205,16 +205,16 @@ protected:
                                                         const AssetClass& assetClass, const Date& expiryDate) override {
         // We follow the way FdBlackScholesBarrierEngine determines maturity for time grid generation
         Handle<YieldTermStructure> riskFreeRate =
-            market_->discountCurve(ccy.code(), configuration(ore::data::MarketContext::pricing));
+            market_->discountCurve(ccy.code(), configuration(MarketContext::pricing));
         Time expiry = riskFreeRate->dayCounter().yearFraction(riskFreeRate->referenceDate(), expiryDate);
         QL_REQUIRE(expiry > 0.0, "FdBlackScholesVanillaEngine expects a positive time to expiry but got "
                                      << expiry << " for an expiry date " << io::iso_date(expiryDate) << ".");
 
         FdmSchemeDesc scheme = parseFdmSchemeDesc(engineParameter("Scheme"));
-        Size tGrid = (Size)(ore::data::parseInteger(engineParameter("TimeGridPerYear")) * expiry);
-        Size xGrid = ore::data::parseInteger(engineParameter("XGrid"));
-        Size dampingSteps = ore::data::parseInteger(engineParameter("DampingSteps"));
-        bool monotoneVar = ore::data::parseBool(engineParameter("EnforceMonotoneVariance", "", false, "true"));
+        Size tGrid = (Size)(parseInteger(engineParameter("TimeGridPerYear")) * expiry);
+        Size xGrid = parseInteger(engineParameter("XGrid"));
+        Size dampingSteps = parseInteger(engineParameter("DampingSteps"));
+        bool monotoneVar = parseBool(engineParameter("EnforceMonotoneVariance", "", false, "true"));
         Size tGridMin = parseInteger(engineParameter("TGridMinimum", "", false, "0"));
         tGrid = std::max(tGridMin, tGrid);
 

--- a/OREData/ored/portfolio/builders/vanillaoption.hpp
+++ b/OREData/ored/portfolio/builders/vanillaoption.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library

--- a/OREData/ored/portfolio/builders/vanillaoption.hpp
+++ b/OREData/ored/portfolio/builders/vanillaoption.hpp
@@ -215,6 +215,8 @@ protected:
         Size xGrid = ore::data::parseInteger(engineParameter("XGrid"));
         Size dampingSteps = ore::data::parseInteger(engineParameter("DampingSteps"));
         bool monotoneVar = ore::data::parseBool(engineParameter("EnforceMonotoneVariance", "", false, "true"));
+        Size tGridMin = parseInteger(engineParameter("TGridMinimum", "", false, "0"));
+        tGrid = std::max(tGridMin, tGrid);
 
         boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp;
 


### PR DESCRIPTION
Hi all,
In our developments, we created a "Greeks report" written from the `ReportWriter` after the standard reports. We use this report to print the Greeks of vanilla options (currently only being QL's `OneAssetOption`) where we noticed poor performance due to the grid choices in `AmericanOptionFDEngineBuilder` for short expiries. This is directly related to a [QL discussion](https://github.com/lballabio/QuantLib/issues/779) from a few years back. It becomes an issue when expiry is around 2 weeks or less, for example: when expiry is in 7 days, we have `t = 0.0192` times `TimeGridPerYear = 100`, yielding `tGrid = 1` currently.

 I see a few solutions to this which I'll list below:
1. Greatly increase _TimeGridPerYear_ in the _pricingengine.xml_ - simple (no coding) but inefficient for longer maturities. 
2. Hardcode minimum values for the T-grid axis - less dynamic, breaks no tests.
3. Allow for optional user-defined minimum values - more dynamic, breaks no tests but complicates logic.

I've made a fix following the third option and I'm open to discussion on the specific minimum values or if this should in fact be included or excluded. I believe it is a good way to ensure that any future extensions can avoid numerical issues and it should not impact the valuation performance in a noticeable manner for short expiries.

Documentation: Added to _Examples/Input/pricingengine.xml_.

Best regards,
Fredrik Gerdin Börjesson.
SEB