### PR TITLE
Equity moneyness volatility surfaces

### DIFF
--- a/OREData/ored/configuration/equityvolcurveconfig.cpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -19,6 +20,7 @@
 #include <ored/configuration/equityvolcurveconfig.hpp>
 #include <ored/utilities/parsers.hpp>
 #include <ored/utilities/to_string.hpp>
+#include <ored/utilities/log.hpp>
 #include <ql/errors.hpp>
 
 using ore::data::XMLUtils;
@@ -29,9 +31,11 @@ namespace data {
 EquityVolatilityCurveConfig::EquityVolatilityCurveConfig(const string& curveID, const string& curveDescription,
                                                          const string& currency,
                                                          const boost::shared_ptr<VolatilityConfig>& volatilityConfig,
-                                                         const string& dayCounter, const string& calendar)
+                                                         const string& dayCounter, const string& calendar,
+                                                         const std::string& equityCurveId,
+                                                         const std::string& yieldCurveId)
     : CurveConfig(curveID, curveDescription), ccy_(currency), volatilityConfig_(volatilityConfig),
-      dayCounter_(dayCounter), calendar_(calendar) {
+      dayCounter_(dayCounter), calendar_(calendar), equityCurveId_(equityCurveId), yieldCurveId_(yieldCurveId) {
     populateQuotes();
 }
 
@@ -107,8 +111,11 @@ void EquityVolatilityCurveConfig::fromXML(XMLNode* node) {
             } else {
                 Size i = 0;
                 for (auto ex : expiries) {
-                    quotes[i] = (quoteStem + ex + "/ATMF");
+                    // TODO: /ATMF or /ATM/AtmFwd? How to preserve backward compatibility with updated strike handling?
+                    quotes[i] = (quoteStem + ex + "/ATM/AtmFwd");
                     i++;
+                    WLOG("Using deprecated configuration of ATM curve. Quotes may not be read if denoting ATM forward "
+                         << "quotes by /ATMF. Consider using /ATM/AtmFwd instead.");
                 }
             }
             volatilityConfig_ = boost::make_shared<VolatilityCurveConfig>(quotes, timeExtrapolation, timeExtrapolation);
@@ -121,28 +128,39 @@ void EquityVolatilityCurveConfig::fromXML(XMLNode* node) {
     } else if (dim == "") {
         XMLNode* n;
         if ((n = XMLUtils::getChildNode(node, "Constant"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type ConstantVolatilityConfig");
             volatilityConfig_ = boost::make_shared<ConstantVolatilityConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "Curve"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityCurveConfig");
             volatilityConfig_ = boost::make_shared<VolatilityCurveConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "StrikeSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityStrikeSurfaceConfig");
             volatilityConfig_ = boost::make_shared<VolatilityStrikeSurfaceConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "DeltaSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityDeltaSurfaceConfig");
             QL_FAIL("DeltaSurface not currently supported for equity volatilities.");
         } else if ((n = XMLUtils::getChildNode(node, "MoneynessSurface"))) {
-            QL_FAIL("MoneynessSurface not currently supported for equity volatilities.");
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityMoneynessSurfaceConfig");
+            volatilityConfig_ = boost::make_shared<VolatilityMoneynessSurfaceConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "ApoFutureSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityApoFutureSurfaceConfig");
             QL_FAIL("ApoFutureSurface not supported for equity volatilities.");
         } else if ((n = XMLUtils::getChildNode(node, "ProxySurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type ProxySurface");
             proxySurface_ = XMLUtils::getChildValue(node, "ProxySurface", true);
         } else {
             QL_FAIL("EquityVolatility node expects one child node with name in list: Constant,"
-                    << " Curve, StrikeSurface, ProxySurface.");
+                    << " Curve, StrikeSurface, MoneynessSurface, ProxySurface.");
         }
         if (proxySurface_.empty())
             volatilityConfig_->fromXML(n);
     } else {
         QL_FAIL("Only ATM and Smile dimensions, or Volatility Config supported for EquityVolatility " << curveID_);
     }
+
+    equityCurveId_ = XMLUtils::getChildValue(node, "EquityCurveId", false);
+    yieldCurveId_ = XMLUtils::getChildValue(node, "YieldCurveId", false);
+
     populateQuotes();
 }
 
@@ -163,6 +181,10 @@ XMLNode* EquityVolatilityCurveConfig::toXML(XMLDocument& doc) {
     }
     if (calendar_ != "NullCalendar")
         XMLUtils::addChild(doc, node, "Calendar", calendar_);
+    if (!equityCurveId_.empty())
+        XMLUtils::addChild(doc, node, "EquityCurveId", equityCurveId_);
+    if (!yieldCurveId_.empty())
+        XMLUtils::addChild(doc, node, "YieldCurveId", yieldCurveId_);
 
     return node;
 }

--- a/OREData/ored/configuration/equityvolcurveconfig.hpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.hpp
@@ -71,7 +71,6 @@ public:
     const boost::shared_ptr<VolatilityConfig>& volatilityConfig() const { return volatilityConfig_; };
     const string& proxySurface() const { return proxySurface_; }
     const string quoteStem() const;
-    void populateQuotes();
     bool isProxySurface() { return !proxySurface_.empty(); };
     const std::string& equityCurveId() const { return equityCurveId_; };
     const std::string& yieldCurveId() const { return yieldCurveId_; };
@@ -91,6 +90,9 @@ private:
     string proxySurface_;
     std::string equityCurveId_;
     std::string yieldCurveId_;
+
+    //! Populate CurveConfig::quotes_ with the required quotes.
+    void populateQuotes();
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/configuration/equityvolcurveconfig.hpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -50,7 +51,8 @@ public:
     //! Detailed constructor
     EquityVolatilityCurveConfig(const string& curveID, const string& curveDescription, const string& currency,
                                 const boost::shared_ptr<VolatilityConfig>& volatilityConfig,
-                                const string& dayCounter = "A365", const string& calendar = "NullCalendar");
+                                const string& dayCounter = "A365", const string& calendar = "NullCalendar",
+                                const std::string& equityCurveId = "", const std::string& yieldCurveId = "");
     //@}
 
     //! \name Serialisation
@@ -71,6 +73,8 @@ public:
     const string quoteStem() const;
     void populateQuotes();
     bool isProxySurface() { return !proxySurface_.empty(); };
+    const std::string& equityCurveId() const { return equityCurveId_; };
+    const std::string& yieldCurveId() const { return yieldCurveId_; };
     //@}
 
     //! \name Setters
@@ -85,6 +89,8 @@ private:
     string dayCounter_;
     string calendar_;
     string proxySurface_;
+    std::string equityCurveId_;
+    std::string yieldCurveId_;
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/configuration/volatilityconfig.hpp
+++ b/OREData/ored/configuration/volatilityconfig.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2019 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -267,6 +268,12 @@ private:
  */
 class VolatilityMoneynessSurfaceConfig : public VolatilitySurfaceConfig {
 public:
+    // TODO: Ideally this enum and tag reader should be in Volatility(Surface)Config
+    // to allow toggling of interpolation on variance vs volatility for all applicable
+    // curve/surface types. Only added here now as we only have support for vol 
+    // interpolation in the case of moneyness surfaces.
+    enum class InterpolationVariable {Variance, Volatility};
+
     //! Default constructor
     VolatilityMoneynessSurfaceConfig(MarketDatum::QuoteType quoteType = MarketDatum::QuoteType::RATE_LNVOL,
                                      QuantLib::Exercise::Type exerciseType = QuantLib::Exercise::Type::European);
@@ -278,7 +285,8 @@ public:
                                      const std::string& timeExtrapolation, const std::string& strikeExtrapolation,
                                      bool futurePriceCorrection = true,
                                      MarketDatum::QuoteType quoteType = MarketDatum::QuoteType::RATE_LNVOL,
-                                     QuantLib::Exercise::Type exerciseType = QuantLib::Exercise::Type::European);
+                                     QuantLib::Exercise::Type exerciseType = QuantLib::Exercise::Type::European,
+                                     InterpolationVariable interpolationVariable = InterpolationVariable::Variance);
 
     //! \name Inspectors
     //@{
@@ -286,6 +294,7 @@ public:
     const std::vector<std::string>& moneynessLevels() const;
     const std::vector<std::string>& expiries() const;
     bool futurePriceCorrection() const;
+    InterpolationVariable interpolationVariable() const;
     //@}
 
     //! \name VolatilitySurfaceConfig
@@ -304,6 +313,9 @@ private:
     std::vector<std::string> moneynessLevels_;
     std::vector<std::string> expiries_;
     bool futurePriceCorrection_;
+    InterpolationVariable interpolationVariable_;
+
+    InterpolationVariable parseInterpolationVariable(const std::string& interpolationVariable) const;
 };
 
 /*! Volatility configuration for an average future price option (APO) surface.

--- a/OREData/ored/marketdata/equitycurve.cpp
+++ b/OREData/ored/marketdata/equitycurve.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -287,10 +288,15 @@ EquityCurve::EquityCurve(Date asof, EquityCurveSpec spec, const Loader& loader, 
                                                                                  << calls[i]->strike());
                             callDates.push_back(getDateFromDateOrPeriod(calls[i]->expiry(), asof));
                             putDates.push_back(getDateFromDateOrPeriod(puts[j]->expiry(), asof));
-                            callStrikes.push_back(parseReal(calls[i]->strike()));
-                            putStrikes.push_back(parseReal(puts[j]->strike()));
                             callPremiums.push_back(calls[i]->quote()->value());
                             putPremiums.push_back(puts[j]->quote()->value());
+
+                            boost::shared_ptr<ore::data::AbsoluteStrike> callStrike =
+                                boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(calls[i]->strike());
+                            callStrikes.push_back(callStrike->strike());
+                            boost::shared_ptr<ore::data::AbsoluteStrike> putStrike =
+                                boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(puts[j]->strike());
+                            putStrikes.push_back(putStrike->strike());
                         }
                     }
                 }

--- a/OREData/ored/marketdata/equityvolcurve.cpp
+++ b/OREData/ored/marketdata/equityvolcurve.cpp
@@ -167,7 +167,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
         // Create the regular expression
         regex regexp(boost::replace_all_copy(vcc.quotes()[0], "*", ".*"));
 
-        // Loop over quotes and process commodity option quotes matching pattern on asof
+        // Loop over quotes and process equity option quotes matching pattern on asof
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
 
             // Go to next quote if the market data point's date does not equal our asof
@@ -200,7 +200,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
 
         DLOG("Have " << vcc.quotes().size() << " explicit quotes");
 
-        // Loop over quotes and process commodity option quotes that are explicitly specified in the config
+        // Loop over quotes and process equity option quotes that are explicitly specified in the config
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
             // Go to next quote if the market data point's date does not equal our asof
             if (md->asofDate() != asof)
@@ -287,8 +287,9 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
 void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConfig& vc,
                                      const VolatilityStrikeSurfaceConfig& vssc, const Loader& loader,
                                      const QuantLib::Handle<EquityIndex>& eqIndex) {
-    try {
+    LOG("EquityVolCurve: start building 2-D volatility absolute strike surface");
 
+    try {
         QL_REQUIRE(vssc.expiries().size() > 0, "No expiries defined");
         QL_REQUIRE(vssc.strikes().size() > 0, "No strikes defined");
 
@@ -396,15 +397,15 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
                            "Call and Put quotes must match for explicitly defined surface, "
                                << callQuotesAdded << " call quotes, and " << putQuotesAdded << " put quotes");
                 DLOG("EquityVolatilityCurve " << vc.curveID() << ": Complete set of " << callQuotesAdded
-                                              << ", call and put quotes found.");
+                                              << " call and put quotes found.");
             }
         }
 
         QL_REQUIRE(callStrikes.size() == callData.size() && callData.size() == callExpiries.size(),
-                   "Quotes loaded don't produce strike,vol,expiry vectors of equal length.");
+                   "Quotes loaded don't produce strike, vol, expiry vectors of equal length.");
         QL_REQUIRE(putStrikes.size() == putData.size() && putData.size() == putExpiries.size(),
-                   "Quotes loaded don't produce strike,vol,expiry vectors of equal length.");
-        DLOG("EquityVolatilityCurve " << vc.curveID() << ": Found " << callQuotesAdded << ", call quotes and "
+                   "Quotes loaded don't produce strike, vol, expiry vectors of equal length.");
+        DLOG("EquityVolatilityCurve " << vc.curveID() << ": Found " << callQuotesAdded << " call quotes and "
                                       << putQuotesAdded << " put quotes using wildcard.");
 
         // Set the strike extrapolation which only matters if extrapolation is turned on for the whole surface.
@@ -494,6 +495,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
         DLOG("Setting BlackVarianceSurfaceSparse extrapolation to " << to_string(vssc.extrapolation()));
         vol_->enableExtrapolation(vssc.extrapolation());
 
+        LOG("EquityVolCurve: finished building 2-D volatility absolute strike surface");
     } catch (std::exception& e) {
         QL_FAIL("equity vol curve building failed :" << e.what());
     } catch (...) {

--- a/OREData/ored/marketdata/equityvolcurve.hpp
+++ b/OREData/ored/marketdata/equityvolcurve.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -49,6 +50,7 @@ public:
     //! Detailed constructor
     EquityVolCurve(Date asof, EquityVolatilityCurveSpec spec, const Loader& loader,
                    const CurveConfigurations& curveConfigs, const QuantLib::Handle<QuantExt::EquityIndex>& eqIndex,
+                   const map<string, boost::shared_ptr<YieldCurve>>& requiredYieldCurves = {},
                    const map<string, boost::shared_ptr<EquityCurve>>& requiredEquityCurves = {},
                    const map<string, boost::shared_ptr<EquityVolCurve>>& requiredEquityVolCurves = {});
     //@}
@@ -70,6 +72,11 @@ public:
                          const VolatilityStrikeSurfaceConfig& vssc, const Loader& loader,
                          const QuantLib::Handle<QuantExt::EquityIndex>& eqIndex);
 
+    /*! Build a volatility surface from a collection of expiry and strike pairs where the strikes are defined in
+    terms of moneyness levels.*/
+    void buildVolatility(const QuantLib::Date& asof, EquityVolatilityCurveConfig& vc,
+                         const VolatilityMoneynessSurfaceConfig& vmsc, const Loader& loader);
+
     //! Build a volatility surface as a proxy from another volatility surface
     void buildVolatility(const QuantLib::Date& asof, const EquityVolatilityCurveSpec& spec,
                          const CurveConfigurations& curveConfigs,
@@ -83,6 +90,19 @@ private:
     boost::shared_ptr<BlackVolTermStructure> vol_;
     QuantLib::Calendar calendar_;
     QuantLib::DayCounter dayCounter_;
+
+    //! Populated for delta and moneyness surfaces and left empty for others
+    QuantLib::Handle<QuantExt::EquityIndex> eqInd_;
+    QuantLib::Handle<QuantLib::YieldTermStructure> yts_;
+
+    //! Populate equity index, \p eqInd_, and yield curve, \p yts_.
+    void populateCurves(const EquityVolatilityCurveConfig& config,
+                        const std::map<std::string, boost::shared_ptr<YieldCurve>>& yieldCurves,
+                        const std::map<std::string, boost::shared_ptr<EquityCurve>>& equityCurves,
+                        const bool deltaOrFwdMoneyness);
+
+    //! Control validity of moneynesses and populate returning vector
+    std::vector<QuantLib::Real> checkMoneyness(const std::vector<std::string>& strMoneynessLevels) const;
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/marketdata/equityvolcurve.hpp
+++ b/OREData/ored/marketdata/equityvolcurve.hpp
@@ -59,11 +59,11 @@ public:
     //@{
     const EquityVolatilityCurveSpec& spec() const { return spec_; }
 
-    //! Build a volatility structure from a single constant volatlity quote
+    //! Build a volatility structure from a single constant volatility quote
     void buildVolatility(const QuantLib::Date& asof, const EquityVolatilityCurveConfig& vc,
                          const ConstantVolatilityConfig& cvc, const Loader& loader);
 
-    //! Build a volatility curve from a 1-D curve of volatlity quotes
+    //! Build a volatility curve from a 1-D curve of volatility quotes
     void buildVolatility(const QuantLib::Date& asof, const EquityVolatilityCurveConfig& vc,
                          const VolatilityCurveConfig& vcc, const Loader& loader);
 

--- a/OREData/ored/marketdata/marketdatum.cpp
+++ b/OREData/ored/marketdata/marketdatum.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -56,7 +57,8 @@ std::ostream& operator<<(std::ostream& out, const MarketDatum::QuoteType& type) 
 }
 
 EquityOptionQuote::EquityOptionQuote(Real value, Date asofDate, const string& name, QuoteType quoteType,
-                                     string equityName, string ccy, string expiry, string strike, bool isCall)
+                                     string equityName, string ccy, string expiry,
+                                     const boost::shared_ptr<BaseStrike>& strike, bool isCall)
     : MarketDatum(value, asofDate, name, quoteType, InstrumentType::EQUITY_OPTION), eqName_(equityName), ccy_(ccy),
       expiry_(expiry), strike_(strike), isCall_(isCall) {
 

--- a/OREData/ored/marketdata/marketdatum.hpp
+++ b/OREData/ored/marketdata/marketdatum.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -1499,7 +1500,7 @@ Specific data comprise
 - Equity/Index name
 - currency
 - expiry
-- strike - can be "ATMF" or an actual strike
+- strike - can be "ATMF" (or, equivalently, "ATM/AtmFwd"), "MNY/Spot|Fwd/MONEYNESS_VALUE", or an absolute strike
 
 \ingroup marketdata
 */
@@ -1508,21 +1509,21 @@ public:
     EquityOptionQuote() {}
     //! Constructor
     EquityOptionQuote(Real value, Date asofDate, const string& name, QuoteType quoteType, string equityName, string ccy,
-                      string expiry, string strike, bool isCall = true);
+                      string expiry, const boost::shared_ptr<BaseStrike>& strike, bool isCall = true);
 
     //! \name Inspectors
     //@{
     const string& eqName() const { return eqName_; }
     const string& ccy() const { return ccy_; }
     const string& expiry() const { return expiry_; }
-    const string& strike() const { return strike_; }
+    const boost::shared_ptr<BaseStrike>& strike() const { return strike_; }
     bool isCall() { return isCall_; }
     //@}
 private:
     string eqName_;
     string ccy_;
     string expiry_;
-    string strike_;
+    boost::shared_ptr<BaseStrike> strike_;
     bool isCall_;
     //! Serialization
     friend class boost::serialization::access;

--- a/OREData/ored/marketdata/marketdatumparser.cpp
+++ b/OREData/ored/marketdata/marketdatumparser.cpp
@@ -410,7 +410,7 @@ boost::shared_ptr<MarketDatum> parseMarketDatum(const Date& asof, const string& 
         const string& index = tokens[2];
         Period term = parsePeriod(tokens[3]);
         QL_REQUIRE(tokens[4] == "C" || tokens[4] == "F",
-                   "excepted C or F for Cap or Floor at position 5 in " << datumName);
+                   "expected C or F for Cap or Floor at position 5 in " << datumName);
         bool isCap = tokens[4] == "C";
         string strike = tokens[5];
         return boost::make_shared<ZcInflationCapFloorQuote>(value, asof, datumName, quoteType, index, term, isCap,
@@ -422,7 +422,7 @@ boost::shared_ptr<MarketDatum> parseMarketDatum(const Date& asof, const string& 
         const string& index = tokens[2];
         Period term = parsePeriod(tokens[3]);
         QL_REQUIRE(tokens[4] == "C" || tokens[4] == "F",
-                   "excepted C or F for Cap or Floor at position 5 in " << datumName);
+                   "expected C or F for Cap or Floor at position 5 in " << datumName);
         bool isCap = tokens[4] == "C";
         string strike = tokens[5];
         return boost::make_shared<YyInflationCapFloorQuote>(value, asof, datumName, quoteType, index, term, isCap,

--- a/OREData/ored/marketdata/marketdatumparser.cpp
+++ b/OREData/ored/marketdata/marketdatumparser.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -463,19 +464,40 @@ boost::shared_ptr<MarketDatum> parseMarketDatum(const Date& asof, const string& 
     }
 
     case MarketDatum::InstrumentType::EQUITY_OPTION: {
-        QL_REQUIRE(tokens.size() == 6 || tokens.size() == 7, "6 or 7 tokens expected in " << datumName);
+        QL_REQUIRE(tokens.size() == 6 || tokens.size() == 7 || tokens.size() == 8,
+                   "6 to 8 tokens expected in " << datumName);
         QL_REQUIRE(quoteType == MarketDatum::QuoteType::RATE_LNVOL || quoteType == MarketDatum::QuoteType::PRICE,
                    "Invalid quote type for " << datumName);
         const string& equityName = tokens[2];
         const string& ccy = tokens[3];
         string expiryString = tokens[4];
-        const string& strike = tokens[5];
+        string& strStrike = tokens[5];
         bool isCall = true;
-        if (tokens.size() == 7) {
-            QL_REQUIRE(tokens[6] == "C" || tokens[6] == "P",
-                       "excepted C or P for Call or Put at position 7 in " << datumName);
-            isCall = tokens[6] == "C";
+
+        double temp = 0;
+        if (tryParseReal(strStrike, temp)) { // Should be absolute strike
+            // Check if Call/Put is specified
+            if (tokens.size() == 7) {
+                QL_REQUIRE(tokens[6] == "C" || tokens[6] == "P",
+                           "expected C or P for Call or Put at position 7 in " << datumName);
+                isCall = tokens[6] == "C";
+            }
+        } else if (strStrike == "ATMF") {                      // Is ATM forward quote
+            strStrike = "ATM/AtmFwd";                          // We force it for parseBaseStrike() to use AtmStrike
+        } else if (strStrike == "ATM" && tokens.size() == 7) { // Should be ATM forward quote, needs 7th token
+            QL_REQUIRE(tokens[6] == "AtmFwd",
+                       "Expected ATM type AtmFwd at position 7, given ATM at position 6, in " << datumName);
+            strStrike = "ATM/AtmFwd";
+        } else if (tokens.size() == 8) { // Else, if 8, should be moneyness strike
+            QL_REQUIRE(tokens[5] == "MNY",
+                       "Expected MNY at position 6 in "
+                           << datumName << " for moneyness surface. MNY/Spot|Fwd");
+            strStrike = boost::algorithm::join(boost::make_iterator_range(tokens.begin() + 5, tokens.begin() + 8), "/");
+        } else {
+            QL_FAIL("unknown equity option quote string. Use ATM/AtmFwd, MNY/Spot|Fwd, or absolute strike 123[/C|P]");
         }
+        boost::shared_ptr<BaseStrike> strike = parseBaseStrike(strStrike);
+
         // note how we only store the expiry string - to ensure we can support both Periods and Dates being specified in
         // the vol curve-config.
         return boost::make_shared<EquityOptionQuote>(value, asof, datumName, quoteType, equityName, ccy, expiryString,

--- a/OREData/ored/marketdata/todaysmarket.cpp
+++ b/OREData/ored/marketdata/todaysmarket.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -600,8 +601,9 @@ TodaysMarket::TodaysMarket(const Date& asof, const TodaysMarketParameters& param
                             MarketImpl::equityCurve(eqvolspec->curveConfigID(), configuration.first);
 
                         boost::shared_ptr<EquityVolCurve> eqVolCurve =
-                            boost::make_shared<EquityVolCurve>(asof, *eqvolspec, loader, curveConfigs, eqIndex,
-                                                               requiredEquityCurves, requiredEquityVolCurves);
+                            boost::make_shared<EquityVolCurve>(asof, *eqvolspec, loader, curveConfigs, eqIndex, 
+                                                               requiredYieldCurves, requiredEquityCurves, 
+                                                               requiredEquityVolCurves);
                         itr = requiredEquityVolCurves.insert(make_pair(eqvolspec->name(), eqVolCurve)).first;
                     }
 

--- a/OREData/test/equitymarketdata.cpp
+++ b/OREData/test/equitymarketdata.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -54,7 +55,9 @@ std::vector<std::string> getMarketDataStrings() {
         ("20160226 EQUITY_OPTION/RATE_LNVOL/SP5/USD/20170226/ATMF 0.25")
         ("20160226 EQUITY_OPTION/RATE_LNVOL/SP5/USD/365D/ATMF 0.25")
         ("20160226 EQUITY_OPTION/RATE_LNVOL/SP5/USD/1678W5D/ATMF 0.25")
-        ("20160226 EQUITY_OPTION/RATE_LNVOL/Lufthansa/EUR/1Y1M/ATMF 0.13");
+        ("20160226 EQUITY_OPTION/RATE_LNVOL/Lufthansa/EUR/1Y1M/ATMF 0.13")
+        ("20160226 EQUITY_OPTION/RATE_LNVOL/Lufthansa/EUR/1Y1M/ATM/AtmFwd 0.13")
+        ("20160226 EQUITY_OPTION/RATE_LNVOL/Lufthansa/EUR/1Y1M/MNY/Fwd/1.0 0.13");
 }
 
 std::vector<std::string> getBadMarketDataStrings() {

--- a/QuantExt/QuantExt.vcxproj
+++ b/QuantExt/QuantExt.vcxproj
@@ -489,6 +489,7 @@
     </Bscmake>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="qle\termstructures\blackvolatilitysurfacemoneyness.hpp" />
     <ClInclude Include="qle\auto_link.hpp" />
     <ClInclude Include="qle\calendars\austria.hpp" />
     <ClInclude Include="qle\calendars\belgium.hpp" />
@@ -785,6 +786,7 @@
     <ClInclude Include="qle\time\yearcounter.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="qle\termstructures\blackvolatilitysurfacemoneyness.cpp" />
     <ClCompile Include="qle\calendars\austria.cpp" />
     <ClCompile Include="qle\calendars\belgium.cpp" />
     <ClCompile Include="qle\calendars\chile.cpp" />

--- a/QuantExt/QuantExt.vcxproj.filters
+++ b/QuantExt/QuantExt.vcxproj.filters
@@ -900,6 +900,9 @@
     <ClInclude Include="qle\indexes\ibor\dkkcita.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="qle\termstructures\blackvolatilitysurfacemoneyness.hpp">
+      <Filter>termstructures</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="cashflows">
@@ -1542,6 +1545,9 @@
     </ClCompile>
     <ClCompile Include="qle\pricingengines\analyticcashsettledeuropeanengine.cpp">
       <Filter>pricingengines</Filter>
+    </ClCompile>
+    <ClCompile Include="qle\termstructures\blackvolatilitysurfacemoneyness.cpp">
+      <Filter>termstructures</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/QuantExt/qle/CMakeLists.txt
+++ b/QuantExt/qle/CMakeLists.txt
@@ -145,6 +145,7 @@ termstructures/blackvariancecurve3.cpp
 termstructures/blackvariancesurfacemoneyness.cpp
 termstructures/blackvariancesurfacesparse.cpp
 termstructures/blackvariancesurfacestddevs.cpp
+termstructures/blackvolatilitysurfacemoneyness.cpp
 termstructures/blackvolsurfacedelta.cpp
 termstructures/blackvolsurfacewithatm.cpp
 termstructures/brlcdiratehelper.cpp

--- a/QuantExt/qle/termstructures/Makefile.am
+++ b/QuantExt/qle/termstructures/Makefile.am
@@ -35,6 +35,7 @@ libTermStructures_la_SOURCES = \
 	subperiodsswaphelper.cpp \
 	defaultprobabilityhelpers.cpp \
 	blackvariancesurfacemoneyness.cpp \
+	blackvolatilitysurfacemoneyness.cpp \
 	blackvolsurfacewithatm.cpp \
 	swaptionvolcube2.cpp \
 	fxvannavolgasmilesection.cpp \
@@ -92,6 +93,7 @@ this_include_HEADERS = \
 	swaptionvolcubewithatm.hpp \
 	swaptionvolconstantspread.hpp \
 	blackvariancesurfacemoneyness.hpp \
+	blackvolatilitysurfacemoneyness.hpp \
     equityvolconstantspread.hpp \
 	swaptionvolcube2.hpp \
 	yoyinflationcurveobserverstatic.hpp \

--- a/QuantExt/qle/termstructures/blackvolatilitysurfacemoneyness.cpp
+++ b/QuantExt/qle/termstructures/blackvolatilitysurfacemoneyness.cpp
@@ -1,0 +1,209 @@
+/*
+ Copyright (C) 2017 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+#include <boost/make_shared.hpp>
+#include <ql/math/interpolations/bilinearinterpolation.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/forwardcurve.hpp>
+#include <ql/utilities/dataformatters.hpp>
+#include <qle/termstructures/blackvolatilitysurfacemoneyness.hpp>
+
+using namespace std;
+
+namespace QuantExt {
+
+BlackVolatilitySurfaceMoneyness::BlackVolatilitySurfaceMoneyness(
+    const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times, const std::vector<Real>& moneyness,
+    const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix, const DayCounter& dayCounter, bool stickyStrike,
+    bool flatExtrapMoneyness)
+    : BlackVolatilityTermStructure(0, cal, Following, dayCounter), stickyStrike_(stickyStrike), spot_(spot),
+      times_(times), moneyness_(moneyness), flatExtrapMoneyness_(flatExtrapMoneyness), quotes_(blackVolMatrix) {
+    init();
+}
+
+BlackVolatilitySurfaceMoneyness::BlackVolatilitySurfaceMoneyness(
+    const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times,
+    const std::vector<Real>& moneyness, const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+    const DayCounter& dayCounter, bool stickyStrike, bool flatExtrapMoneyness)
+    : BlackVolatilityTermStructure(referenceDate, cal, Following, dayCounter), stickyStrike_(stickyStrike), spot_(spot),
+      times_(times), moneyness_(moneyness), flatExtrapMoneyness_(flatExtrapMoneyness), quotes_(blackVolMatrix) {
+    init();
+}
+
+void BlackVolatilitySurfaceMoneyness::update() {
+    TermStructure::update();
+    LazyObject::update();
+}
+
+void BlackVolatilitySurfaceMoneyness::performCalculations() const {
+    for (Size j = 1; j < volatilities_.columns(); j++) {
+        for (Size i = 0; i < volatilities_.rows(); i++) {
+            Real vol = quotes_[i][j - 1]->value();
+            volatilities_[i][j] = vol;
+        }
+    }
+    volatilitySurface_.update();
+}
+
+void BlackVolatilitySurfaceMoneyness::init() {
+    QL_REQUIRE(times_.size() == quotes_.front().size(), "mismatch between times vector and vol matrix colums");
+    QL_REQUIRE(moneyness_.size() == quotes_.size(), "mismatch between moneyness vector and vol matrix rows");
+
+    QL_REQUIRE(times_[0] > 0, "The first time must be greater than 0.0.");
+
+    if (stickyStrike_) {
+        // we don't want to know if the spot has changed - we take a copy here
+        spot_ = Handle<Quote>(boost::make_shared<SimpleQuote>(spot_->value()));
+    } else {
+        registerWith(spot_);
+    }
+
+    // Insert time 0.0 in times_ and initialise volatilities_ with 0.0.
+    times_.insert(times_.begin(), 0.0);
+    volatilities_ = Matrix(moneyness_.size(), times_.size(), 0.0);
+
+    // Check times_ and register with quotes
+    for (Size j = 1; j < times_.size(); j++) {
+
+        QL_REQUIRE(times_[j] > times_[j - 1], "Times must be sorted and unique but found that the "
+                                                  << io::ordinal(j) << " time, " << times_[j]
+                                                  << ", is not greater than the " << io::ordinal(j - 1) << " time, "
+                                                  << times_[j - 1] << ".");
+
+        for (Size i = 0; i < moneyness_.size(); i++) {
+            registerWith(quotes_[i][j - 1]);
+        }
+    }
+
+    volatilitySurface_ =
+        Bilinear().interpolate(times_.begin(), times_.end(), moneyness_.begin(), moneyness_.end(), volatilities_);
+
+    notifyObservers();
+}
+
+Volatility BlackVolatilitySurfaceMoneyness::blackVolImpl(Time t, Real strike) const {
+    calculate();
+
+    if (t == 0.0)
+        return 0.0;
+
+    return std::sqrt(blackVarianceMoneyness(t, moneyness(t, strike)) / t);
+}
+
+Real BlackVolatilitySurfaceMoneyness::blackVarianceMoneyness(Time t, Real m) const {
+    Real vol = 0.0;
+    if (t <= times_.back()) {
+        vol = volatilitySurface_(t, m, true);
+    } else { // I.e. if t > times_.back(), extrapolate from back()
+        vol = volatilitySurface_(times_.back(), m, true);
+    }
+    return vol * vol * t;
+}
+
+BlackVolatilitySurfaceMoneynessSpot::BlackVolatilitySurfaceMoneynessSpot(
+    const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times, const std::vector<Real>& moneyness,
+    const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix, const DayCounter& dayCounter, bool stickyStrike,
+    bool flatExtrapMoneyness)
+    : BlackVolatilitySurfaceMoneyness(cal, spot, times, moneyness, blackVolMatrix, dayCounter, stickyStrike,
+                                      flatExtrapMoneyness) {}
+
+BlackVolatilitySurfaceMoneynessSpot::BlackVolatilitySurfaceMoneynessSpot(
+    const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times,
+    const std::vector<Real>& moneyness, const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+    const DayCounter& dayCounter, bool stickyStrike, bool flatExtrapMoneyness)
+    : BlackVolatilitySurfaceMoneyness(referenceDate, cal, spot, times, moneyness, blackVolMatrix, dayCounter,
+                                      stickyStrike, flatExtrapMoneyness) {}
+
+Real BlackVolatilitySurfaceMoneynessSpot::moneyness(Time, Real strike) const {
+    if (strike == Null<Real>() || strike == 0) {
+        return 1.0;
+    } else {
+        Real moneyness = strike / spot_->value();
+        if (flatExtrapMoneyness_) {
+            if (moneyness < moneyness_.front()) {
+                moneyness = moneyness_.front();
+            } else if (moneyness > moneyness_.back()) {
+                moneyness = moneyness_.back();
+            }
+        }
+        return moneyness;
+    }
+}
+
+BlackVolatilitySurfaceMoneynessForward::BlackVolatilitySurfaceMoneynessForward(
+    const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times, const std::vector<Real>& moneyness,
+    const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix, const DayCounter& dayCounter,
+    const Handle<YieldTermStructure>& forTS, const Handle<YieldTermStructure>& domTS, bool stickyStrike,
+    bool flatExtrapMoneyness)
+    : BlackVolatilitySurfaceMoneyness(cal, spot, times, moneyness, blackVolMatrix, dayCounter, stickyStrike,
+                                      flatExtrapMoneyness),
+      forTS_(forTS), domTS_(domTS) {
+    init();
+}
+
+BlackVolatilitySurfaceMoneynessForward::BlackVolatilitySurfaceMoneynessForward(
+    const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times,
+    const std::vector<Real>& moneyness, const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+    const DayCounter& dayCounter, const Handle<YieldTermStructure>& forTS, const Handle<YieldTermStructure>& domTS,
+    bool stickyStrike, bool flatExtrapMoneyness)
+    : BlackVolatilitySurfaceMoneyness(referenceDate, cal, spot, times, moneyness, blackVolMatrix, dayCounter,
+                                      stickyStrike, flatExtrapMoneyness),
+      forTS_(forTS), domTS_(domTS) {
+    init();
+}
+
+void BlackVolatilitySurfaceMoneynessForward::init() {
+    if (!stickyStrike_) {
+        QL_REQUIRE(!forTS_.empty(), "foreign discount curve required for moneyness forward surface");
+        QL_REQUIRE(!domTS_.empty(), "domestic discount curve required for moneyness forward surface");
+        registerWith(forTS_);
+        registerWith(domTS_);
+    } else {
+        for (Size i = 0; i < times_.size(); i++) {
+            Time t = times_[i];
+            Real fwd = spot_->value() * forTS_->discount(t) / domTS_->discount(t);
+            forwards_.push_back(fwd);
+        }
+        forwardCurve_ = Linear().interpolate(times_.begin(), times_.end(), forwards_.begin());
+    }
+}
+
+Real BlackVolatilitySurfaceMoneynessForward::moneyness(Time t, Real strike) const {
+    Real fwd;
+    Real reqMoneyness; // for flat extrapolation
+    if (strike == Null<Real>() || strike == 0)
+        return 1.0;
+    else {
+        if (stickyStrike_)
+            fwd = forwardCurve_(t, true);
+        else
+            fwd = spot_->value() * forTS_->discount(t) / domTS_->discount(t);
+        reqMoneyness = strike / fwd;
+        if (flatExtrapMoneyness_) {
+            if ((strike / fwd) < moneyness_.front()) {
+                reqMoneyness = moneyness_.front();
+            } else if ((strike / fwd) > moneyness_.back()) {
+                reqMoneyness = moneyness_.back();
+            }
+        }
+        return reqMoneyness;
+    }
+}
+
+} // namespace QuantExt

--- a/QuantExt/qle/termstructures/blackvolatilitysurfacemoneyness.hpp
+++ b/QuantExt/qle/termstructures/blackvolatilitysurfacemoneyness.hpp
@@ -1,0 +1,177 @@
+/*
+ Copyright (C) 2017 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*! \file blackvolatilitysurfacemoneyness.hpp
+ \brief Black volatility surface based on forward moneyness interpolated on volatility
+ \ingroup termstructures
+ */
+
+#ifndef quantext_black_volatility_surface_moneyness_hpp
+#define quantext_black_volatility_surface_moneyness_hpp
+
+#include <ql/math/interpolation.hpp>
+#include <ql/math/interpolations/interpolation2d.hpp>
+#include <ql/patterns/lazyobject.hpp>
+#include <ql/quote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+
+namespace QuantExt {
+using namespace QuantLib;
+
+/*! Abstract Black volatility surface based on moneyness (moneyness defined in subclasses), 
+    interpolated on volatility instead of variance.
+*/
+/*! \todo times should not be in the interface here. There should be a Dates based constructor and a Periods
+          based constructor. This would cover the cases of fixed expiry options and options specified in terms
+          of tenors. The times should be calculated internally in the class. What is maxDate() when you use times
+          in the interface?
+
+    \ingroup termstructures
+*/
+class BlackVolatilitySurfaceMoneyness : public LazyObject, public BlackVolatilityTermStructure {
+public:
+    /*! Moneyness can be defined here as spot moneyness, i.e. K/S
+     * or forward moneyness, ie K/F
+     */
+    BlackVolatilitySurfaceMoneyness(const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times,
+                                  const std::vector<Real>& moneyness,
+                                  const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                  const DayCounter& dayCounter, bool stickyStrike, bool flatExtrapMoneyness = false);
+
+    //! Moneyness volatility surface with a fixed reference date.
+    BlackVolatilitySurfaceMoneyness(const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot,
+                                  const std::vector<Time>& times, const std::vector<Real>& moneyness,
+                                  const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                  const DayCounter& dayCounter, bool stickyStrike, bool flatExtrapMoneyness = false);
+
+    //! \name TermStructure interface
+    //@{
+    Date maxDate() const { return Date::maxDate(); }
+    //@}
+    //! \name VolatilityTermStructure interface
+    //@{
+    Real minStrike() const { return 0; }
+    Real maxStrike() const { return QL_MAX_REAL; }
+    //@}
+    //! \name Observer interface
+    //@{
+    void update();
+    //@}
+    //! \name LazyObject interface
+    //@{
+    void performCalculations() const;
+    //@}
+    //! \name Visitability
+    //@{
+    virtual void accept(AcyclicVisitor&);
+    //@}
+
+    //! \name Inspectors
+    //@{
+    std::vector<QuantLib::Real> moneyness() const { return moneyness_; }
+    //@}
+
+protected:
+    virtual Real moneyness(Time t, Real strike) const = 0;
+    bool stickyStrike_;
+    Handle<Quote> spot_;
+    std::vector<Time> times_;
+    std::vector<Real> moneyness_;
+    bool flatExtrapMoneyness_;
+
+private:
+    // Shared initialisation
+    void init();
+
+    Real blackVarianceMoneyness(Time t, Real moneyness) const;
+    virtual Volatility blackVolImpl(Time t, Real strike) const;
+    std::vector<std::vector<Handle<Quote> > > quotes_;
+    mutable Matrix volatilities_;
+    mutable Interpolation2D volatilitySurface_;
+};
+
+// inline definitions
+
+inline void BlackVolatilitySurfaceMoneyness::accept(AcyclicVisitor& v) {
+    Visitor<BlackVolatilitySurfaceMoneyness>* v1 = dynamic_cast<Visitor<BlackVolatilitySurfaceMoneyness>*>(&v);
+    if (v1 != 0)
+        v1->visit(*this);
+    else
+        BlackVolatilityTermStructure::accept(v);
+}
+
+//! Black volatility surface based on spot moneyness
+//!  \ingroup termstructures
+class BlackVolatilitySurfaceMoneynessSpot : public BlackVolatilitySurfaceMoneyness {
+public:
+    /*! Moneyness is defined here as spot moneyness, i.e. K/S */
+
+    BlackVolatilitySurfaceMoneynessSpot(const Calendar& cal, const Handle<Quote>& spot, const std::vector<Time>& times,
+                                        const std::vector<Real>& moneyness,
+                                        const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                        const DayCounter& dayCounter, bool stickyStrike = false,
+                                        bool flatExtrapMoneyness = false);
+
+    //! Spot moneyness volatility surface with a fixed reference date.
+    BlackVolatilitySurfaceMoneynessSpot(const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot,
+                                        const std::vector<Time>& times, const std::vector<Real>& moneyness,
+                                        const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                        const DayCounter& dayCounter, bool stickyStrike = false,
+                                        bool flatExtrapMoneyness = false);
+
+private:
+    virtual Real moneyness(Time t, Real strike) const;
+};
+
+//! Black volatility surface based on forward moneyness
+//! \ingroup termstructures
+class BlackVolatilitySurfaceMoneynessForward : public BlackVolatilitySurfaceMoneyness {
+public:
+    /*! Moneyness is defined here as forward moneyness, i.e. K/F */
+
+    BlackVolatilitySurfaceMoneynessForward(const Calendar& cal, const Handle<Quote>& spot,
+                                           const std::vector<Time>& times, const std::vector<Real>& moneyness,
+                                           const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                           const DayCounter& dayCounter, const Handle<YieldTermStructure>& forTS,
+                                           const Handle<YieldTermStructure>& domTS, bool stickyStrike = false,
+                                           bool flatExtrapMoneyness = false);
+
+    //! Forward moneyness volatility surface with a fixed reference date.
+    BlackVolatilitySurfaceMoneynessForward(const Date& referenceDate, const Calendar& cal, const Handle<Quote>& spot,
+                                           const std::vector<Time>& times, const std::vector<Real>& moneyness,
+                                           const std::vector<std::vector<Handle<Quote> > >& blackVolMatrix,
+                                           const DayCounter& dayCounter, const Handle<YieldTermStructure>& forTS,
+                                           const Handle<YieldTermStructure>& domTS, bool stickyStrike = false,
+                                           bool flatExtrapMoneyness = false);
+
+private:
+    // Shared initialisation
+    void init();
+
+    virtual Real moneyness(Time t, Real strike) const;
+    Handle<YieldTermStructure> forTS_; // calculates fwd if StickyStrike==false
+    Handle<YieldTermStructure> domTS_;
+    std::vector<Real> forwards_; // cache fwd values if StickyStrike==true
+    QuantLib::Interpolation forwardCurve_;
+};
+
+} // namespace QuantExt
+
+#endif

--- a/QuantExt/test/CMakeLists.txt
+++ b/QuantExt/test/CMakeLists.txt
@@ -5,6 +5,7 @@ analyticlgmswaptionengine.cpp
 blackvariancecurve.cpp
 blackvariancesurfacesparse.cpp
 blackvariancesurfacestddevs.cpp
+blackvolatilitysurfacemoneyness.cpp
 blackvolsurfacedelta.cpp
 bonds.cpp
 capfloortermvolcurve.cpp

--- a/QuantExt/test/Makefile.am
+++ b/QuantExt/test/Makefile.am
@@ -39,7 +39,8 @@ QLE_TESTS = \
 	cpicapfloor.cpp 
 	correlationtermstructure.cpp \
 	cpicapfloor.cpp \
-	strippedoptionletadapter.cpp
+	strippedoptionletadapter.cpp \
+	blackvolatilitysurfacemoneyness.cpp
 
 dist-hook:
 	mkdir -p $(distdir)/build

--- a/QuantExt/test/blackvolatilitysurfacemoneyness.cpp
+++ b/QuantExt/test/blackvolatilitysurfacemoneyness.cpp
@@ -1,0 +1,218 @@
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include <boost/test/unit_test.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <qle/termstructures/blackvariancesurfacemoneyness.hpp>
+#include <qle/termstructures/blackvolatilitysurfacemoneyness.hpp>
+
+using namespace boost::unit_test_framework;
+using namespace QuantLib;
+using std::vector;
+
+BOOST_FIXTURE_TEST_SUITE(QuantExtTestSuite, qle::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(BlackVolatilitySurfaceMoneyness)
+
+BOOST_AUTO_TEST_CASE(testVolatilitySurfaceMoneynessForward) {
+    BOOST_TEST_MESSAGE("Testing QuantExt::BlackVolatilitySurfaceMoneynessForward");
+
+    SavedSettings backup;
+    Settings::instance().evaluationDate() = Date(1, Dec, 2015);
+    Date today = Settings::instance().evaluationDate();
+
+    // We setup a simple surface, illustrated below by implied (yearly) volatility inputs:
+    // Moneyness\Times: 1.0 2.0
+    // 0.9:   0.35   0.30
+    // 1.1:   0.40   0.35
+    // Then we ask it for vol at different tenors and strikes (moneyness levels)
+
+    Calendar cal = NullCalendar();
+    Handle<Quote> spot = Handle<Quote>(boost::make_shared<SimpleQuote>(100));
+    vector<Time> expiryTimes = { 1.0, 2.0 };
+    vector<Real> moneynessLevels = { 0.9, 1.1 };
+    vector<vector<Handle<Quote> > > blackVolMatrix(moneynessLevels.size(), vector<Handle<Quote> >(expiryTimes.size()));
+
+    blackVolMatrix[0][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+    blackVolMatrix[0][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.30));
+    blackVolMatrix[1][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.40));
+    blackVolMatrix[1][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+
+    DayCounter dc = ActualActual();
+    Handle<YieldTermStructure> forTS(
+        boost::make_shared<FlatForward>(today, Handle<Quote>(boost::make_shared<SimpleQuote>(0.02)), ActualActual()));
+    Handle<YieldTermStructure> domTS(
+        boost::make_shared<FlatForward>(today, Handle<Quote>(boost::make_shared<SimpleQuote>(0.01)), ActualActual()));
+
+    // Create the volatility surface with a spot moneyness dimension
+    QuantExt::BlackVolatilitySurfaceMoneynessForward surface(cal, spot, expiryTimes, moneynessLevels, blackVolMatrix,
+                                                             dc, forTS, domTS, false, true);
+
+    // Check original pillars for correctness
+    for (Size i = 0; i < moneynessLevels.size(); ++i) {
+        for (Size j = 0; j < expiryTimes.size(); ++j) {
+            Time T = expiryTimes[j];
+            Real strike = moneynessLevels[i] * spot->value() * forTS->discount(T) / domTS->discount(T);
+            Volatility vol = surface.blackVol(T, strike);
+
+            BOOST_CHECK_CLOSE(vol, blackVolMatrix[i][j]->value(), 1e-12);
+        }
+    }
+
+    // Finally check the middle point of the surface, i.e. T = 1.5 and Mny = 1.0
+    Time T = 1.5;
+    Real strike = 1.0 * spot->value() * forTS->discount(T) / domTS->discount(T);
+    Volatility vol = surface.blackVol(T, strike);
+    BOOST_CHECK_CLOSE(vol, 0.35, 1e-12);
+
+    // ... and check the same middle point although by its variance value
+    Real var = surface.blackVariance(T, strike);
+    BOOST_CHECK_CLOSE(var, 0.35 * 0.35 * T, 1e-12);
+
+    // ... and before time 1.0, at t = 0.5 (Mny 0.9)
+    T = 0.5;
+    strike = 0.9 * spot->value() * forTS->discount(T) / domTS->discount(T);
+    vol = surface.blackVol(T, strike);
+    BOOST_CHECK_CLOSE(vol, 0.35 * 0.5, 1e-12);
+
+    // ... and, lastly, after time 2.0, at t = 2.5 with Mny 0.9
+    // (note the flat extrapolation)
+    T = 2.5;
+    strike = 0.9 * spot->value() * forTS->discount(T) / domTS->discount(T);
+    vol = surface.blackVol(2.5, strike);
+    BOOST_CHECK_CLOSE(vol, 0.30, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testVolatilitySurfaceMoneynessSpot) {
+    BOOST_TEST_MESSAGE("Testing QuantExt::BlackVolatilitySurfaceMoneynessSpot");
+
+    SavedSettings backup;
+    Settings::instance().evaluationDate() = Date(1, Dec, 2015);
+    Date today = Settings::instance().evaluationDate();
+
+    // We setup a simple surface, illustrated below by implied (yearly) volatility inputs:
+    // Moneyness\Times: 1.0 2.0
+    // 0.9:   0.35   0.30
+    // 1.1:   0.40   0.35
+    // Then we ask it for vol at different tenors and strikes (moneyness levels)
+
+    Calendar cal = NullCalendar();
+    Handle<Quote> spot = Handle<Quote>(boost::make_shared<SimpleQuote>(100));
+    vector<Time> expiryTimes = { 1.0, 2.0 };
+    vector<Real> moneynessLevels = { 0.9, 1.1 };
+    vector<vector<Handle<Quote> > > blackVolMatrix(moneynessLevels.size(), vector<Handle<Quote> >(expiryTimes.size()));
+
+    blackVolMatrix[0][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+    blackVolMatrix[0][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.30));
+    blackVolMatrix[1][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.40));
+    blackVolMatrix[1][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+
+    DayCounter dc = ActualActual();
+
+    // Create the volatility surface with a spot moneyness dimension
+    QuantExt::BlackVolatilitySurfaceMoneynessSpot surface(cal, spot, expiryTimes, moneynessLevels, blackVolMatrix, dc,
+                                                          false, true);
+
+    // Check original pillars for correctness
+    for (Size i = 0; i < moneynessLevels.size(); ++i) {
+        for (Size j = 0; j < expiryTimes.size(); ++j) {
+            Time T = expiryTimes[j];
+            Real strike = moneynessLevels[i] * spot->value();
+            Volatility vol = surface.blackVol(T, strike);
+
+            BOOST_CHECK_CLOSE(vol, blackVolMatrix[i][j]->value(), 1e-12);
+        }
+    }
+
+    // Finally check the middle point of the surface, i.e. T = 1.5 and Mny = 1.0
+    Time T = 1.5;
+    Real strike = 1.0 * spot->value();
+    Volatility vol = surface.blackVol(T, strike);
+    BOOST_CHECK_CLOSE(vol, 0.35, 1e-12);
+
+    // ... and check the same middle point although by its variance value
+    Real var = surface.blackVariance(T, strike);
+    BOOST_CHECK_CLOSE(var, 0.35 * 0.35 * T, 1e-12);
+
+    // ... and before time 1.0, at t = 0.5 (Mny 0.9)
+    T = 0.5;
+    strike = 0.9 * spot->value();
+    vol = surface.blackVol(T, strike);
+    BOOST_CHECK_CLOSE(vol, 0.35 * 0.5, 1e-12);
+
+    // ... and, lastly, after time 2.0, at t = 2.5 with Mny 0.9
+    // (note the flat extrapolation)
+    T = 2.5;
+    strike = 0.9 * spot->value();
+    vol = surface.blackVol(2.5, strike);
+    BOOST_CHECK_CLOSE(vol, 0.30, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testVolatilitySurfaceMoneynessSpotConstistency) {
+    BOOST_TEST_MESSAGE("Testing QuantExt::BlackVarianceSurfaceMoneynessSpot and "
+                       << "QuantExt::BlackVolatilitySurfaceMoneynessSpot for consistency");
+
+    // We setup a simple surface, illustrated below by implied (yearly) volatility inputs:
+    // Moneyness\Times: 1.0 2.0
+    // 0.9:   0.35   0.30
+    // 1.1:   0.40   0.35
+    // Then we ask it for vol at different tenors and strikes (moneyness levels)
+
+    Calendar cal = NullCalendar();
+    Handle<Quote> spot = Handle<Quote>(boost::make_shared<SimpleQuote>(100));
+    vector<Time> expiryTimes = { 1.0, 2.0 };
+    vector<Real> moneynessLevels = { 0.9, 1.1 };
+    vector<vector<Handle<Quote> > > blackVolMatrix(moneynessLevels.size(), vector<Handle<Quote> >(expiryTimes.size()));
+
+    blackVolMatrix[0][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+    blackVolMatrix[0][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.30));
+    blackVolMatrix[1][0] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.40));
+    blackVolMatrix[1][1] = Handle<Quote>(boost::make_shared<SimpleQuote>(0.35));
+
+    DayCounter dc = ActualActual();
+
+    // Create the volatility surface with a spot moneyness dimension
+    QuantExt::BlackVolatilitySurfaceMoneynessSpot volSurface(cal, spot, expiryTimes, moneynessLevels, blackVolMatrix,
+                                                             dc, false, true);
+    // Create the equivalent variance surface with a spot moneyness dimension
+    QuantExt::BlackVarianceSurfaceMoneynessSpot varSurface(cal, spot, expiryTimes, moneynessLevels, blackVolMatrix, dc,
+                                                           false, true);
+
+    // Check original pillars for correctness
+    for (Size i = 0; i < moneynessLevels.size(); ++i) {
+        for (Size j = 0; j < expiryTimes.size(); ++j) {
+            Time T = expiryTimes[j];
+            Real strike = moneynessLevels[i] * spot->value();
+            Volatility vol1 = volSurface.blackVol(T, strike);
+            Volatility vol2 = varSurface.blackVol(T, strike);
+            BOOST_CHECK_CLOSE(vol1, vol2, 1e-12);
+
+            Real var1 = volSurface.blackVariance(T, strike);
+            Real var2 = varSurface.blackVariance(T, strike);
+            BOOST_CHECK_CLOSE(var1, var2, 1e-12);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/QuantExt/test/testsuite.vcxproj
+++ b/QuantExt/test/testsuite.vcxproj
@@ -641,6 +641,7 @@
     <ClCompile Include="blackvariancecurve.cpp" />
     <ClCompile Include="blackvariancesurfacesparse.cpp" />
     <ClCompile Include="blackvariancesurfacestddevs.cpp" />
+    <ClCompile Include="blackvolatilitysurfacemoneyness.cpp" />
     <ClCompile Include="blackvolsurfacedelta.cpp" />
     <ClCompile Include="bonds.cpp" />
     <ClCompile Include="capfloortermvolcurve.cpp" />

--- a/QuantExt/test/testsuite.vcxproj.filters
+++ b/QuantExt/test/testsuite.vcxproj.filters
@@ -158,6 +158,9 @@
     <ClCompile Include="quadraticinterpolation.cpp">
       <Filter>source</Filter>
     </ClCompile>
+    <ClCompile Include="blackvolatilitysurfacemoneyness.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="source">


### PR DESCRIPTION
Hi all,
This PR is to share our extension of the volatility surfaces available for equity options. We have essentially done this in three steps:
1. Updating the equity option market datum parser to use the new `Strike` class that commodity options currently use. This also requires us to update the build functions of the current equity volatility curves/surfaces.
2. Adding the builder function for the class `BlackVarianceSurfaceMoneyness` to the `EquityVolCurve` class. Adding a new class `BlackVolatilitySurfaceMoneyness` for interpolation on volatility rather than variance.
3. Adding the ability to toggle the interpolation variable in the moneyness volatility curve config. 

The complexity in step 1, especially if we want to preserve backwards compatibility, made me wary of sending this PR and I will therefore only draft this until further. The solution is working as is, at least as far as the volatility surfaces go, although I know there are aspects I haven't been able to test (such as the cross asset model, e.g. [here](https://github.com/OpenSourceRisk/Engine/blob/57cb3158b76ab00c643efccc97c07555f01c495f/OREData/ored/model/eqbsbuilder.cpp#L138)). Because of this, I split the updates into three commits, as follows.
1. Contains only `BlackVolatilitySurfaceMoneyness` files and tests, plus updated project/build settings. 
2. Contains the additions to the build functions and the strike revamp.
3. Contains minor fixes for old comments and logs.

Going forward, we would be happy to see this fully incorporated into future versions. I realize this PR comes very close to the ORE 6 release, so perhaps this is better evaluated after that. At this time, I'd believe that commit 1 can be made stand-alone without any issues, and the commits 2--3 can be considered after a more extensive review. I especially think that adding the ability to toggle volatility/variance interpolation (as in Front Arena Prime among other systems) would be beneficial anywhere applicable.

Documentation: None added but will be happy to provide it if this is picked up. 

Tests: 
- BlackVolatilitySurfaceMoneyness tests against expected results.
- The equity market data parser has two test cases added.

Best regards,
Fredrik Gerdin Börjesson,
SEB