### PR TITLE
Add missing interpolation enums to XSD

### DIFF
--- a/xsd/curveconfig.xsd
+++ b/xsd/curveconfig.xsd
@@ -532,9 +532,11 @@
       <xs:enumeration value="Linear"/>
       <xs:enumeration value="LogLinear"/>
       <xs:enumeration value="Cubic"/>
+      <xs:enumeration value="Hermite"/>
       <xs:enumeration value="LinearFlat"/>
       <xs:enumeration value="LogLinearFlat"/>
       <xs:enumeration value="CubicFlat"/>
+      <xs:enumeration value="HermiteFlat"/>
       <xs:enumeration value="BackwardFlat"/>
     </xs:restriction>
   </xs:simpleType>

--- a/xsd/ore_types.xsd
+++ b/xsd/ore_types.xsd
@@ -433,9 +433,14 @@
       <xs:enumeration value="NaturalCubic"/>
       <xs:enumeration value="FinancialCubic"/>
       <xs:enumeration value="Cubic"/>
+      <xs:enumeration value="Hermite"/>
+      <xs:enumeration value="Quadratic"/>
+      <xs:enumeration value="LogQuadratic"/>
+      <xs:enumeration value="CubicSpline"/>
       <xs:enumeration value="LinearFlat"/>
       <xs:enumeration value="LogLinearFlat"/>
       <xs:enumeration value="CubicFlat"/>
+      <xs:enumeration value="HermiteFlat"/>
       <xs:enumeration value="ConvexMonotone"/>
       <xs:enumeration value="ExponentialSplines"/>
       <xs:enumeration value="NelsonSiegel"/>


### PR DESCRIPTION
Hi all,
This is a fix for the newly added interpolation methods to be added into the XSD enum. We noticed that we had overlooked this previously. 

On a side note, the Asian options will also be missing from the XSDs, though we'll strive to help with adding this soon. The same goes for extending their documentation. 

I also wish to give a sincere thank you for your maintaining of ORE and the release of version 6. We'll be looking forward to contribute more.

Best regards,
Fredrik Gerdin Börjesson,
SEB