### PR TITLE
Retarget VS project to use latest available Windows SDK

### DIFF
--- a/App/ore.vcxproj
+++ b/App/ore.vcxproj
@@ -39,7 +39,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ore</RootNamespace>
     <ProjectName>ore</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\ore.props" />


### PR DESCRIPTION
Hi all,
Here's a fix to close #80 that prevents building the VS solution when not having a specific Windows SDK version. This minor retarget lessens the requirements on the user as noted in the issue.

Best regards,
Fredrik Gerdin Börjesson,
SEB