### PR TITLE
Correct FX Asians to reference the GarmanKohlhagen process

### DIFF
--- a/OREData/ored/portfolio/builders/fxasianoption.hpp
+++ b/OREData/ored/portfolio/builders/fxasianoption.hpp
@@ -33,7 +33,7 @@
  class FxEuropeanAsianOptionMCDAAPEngineBuilder : public EuropeanAsianOptionMCDAAPEngineBuilder {
  public:
      FxEuropeanAsianOptionMCDAAPEngineBuilder()
-         : EuropeanAsianOptionMCDAAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
+         : EuropeanAsianOptionMCDAAPEngineBuilder("GarmanKohlhagen", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX,
                                                   expiryDate_) {}
  };
 
@@ -45,7 +45,7 @@
  class FxEuropeanAsianOptionMCDAASEngineBuilder : public EuropeanAsianOptionMCDAASEngineBuilder {
  public:
      FxEuropeanAsianOptionMCDAASEngineBuilder()
-         : EuropeanAsianOptionMCDAASEngineBuilder("BlackScholesMerton", {"FxAsianOptionArithmeticStrike"},
+         : EuropeanAsianOptionMCDAASEngineBuilder("GarmanKohlhagen", {"FxAsianOptionArithmeticStrike"},
                                                   AssetClass::FX, expiryDate_) {}
  };
 
@@ -57,7 +57,7 @@
  class FxEuropeanAsianOptionMCDGAPEngineBuilder : public EuropeanAsianOptionMCDGAPEngineBuilder {
  public:
      FxEuropeanAsianOptionMCDGAPEngineBuilder()
-         : EuropeanAsianOptionMCDGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX,
+         : EuropeanAsianOptionMCDGAPEngineBuilder("GarmanKohlhagen", {"FxAsianOptionGeometricPrice"}, AssetClass::FX,
                                                   expiryDate_) {}
  };
 
@@ -68,7 +68,7 @@
  class FxEuropeanAsianOptionADGAPEngineBuilder : public EuropeanAsianOptionADGAPEngineBuilder {
  public:
      FxEuropeanAsianOptionADGAPEngineBuilder()
-         : EuropeanAsianOptionADGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
+         : EuropeanAsianOptionADGAPEngineBuilder("GarmanKohlhagen", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
      }
  };
 
@@ -79,7 +79,7 @@
  class FxEuropeanAsianOptionADGASEngineBuilder : public EuropeanAsianOptionADGASEngineBuilder {
  public:
      FxEuropeanAsianOptionADGASEngineBuilder()
-         : EuropeanAsianOptionADGASEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricStrike"},
+         : EuropeanAsianOptionADGASEngineBuilder("GarmanKohlhagen", {"FxAsianOptionGeometricStrike"},
                                                  AssetClass::FX) {}
  };
 
@@ -90,7 +90,7 @@
  class FxEuropeanAsianOptionACGAPEngineBuilder : public EuropeanAsianOptionACGAPEngineBuilder {
  public:
      FxEuropeanAsianOptionACGAPEngineBuilder()
-         : EuropeanAsianOptionACGAPEngineBuilder("BlackScholesMerton", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
+         : EuropeanAsianOptionACGAPEngineBuilder("GarmanKohlhagen", {"FxAsianOptionGeometricPrice"}, AssetClass::FX) {
      }
  };
 

--- a/OREData/test/fxasianoption.cpp
+++ b/OREData/test/fxasianoption.cpp
@@ -134,7 +134,7 @@
          market = boost::make_shared<TestMarket>(a.spot, expiry, a.domesticRate, a.foreignRate, a.volatility);
          boost::shared_ptr<EngineData> engineData = boost::make_shared<EngineData>();
          std::string productName = "FxAsianOptionArithmeticPrice";
-         engineData->model(productName) = "BlackScholesMerton";
+         engineData->model(productName) = "GarmanKohlhagen";
          engineData->engine(productName) = "MCDiscreteArithmeticAPEngine";
          engineData->engineParameters(productName) = {{"ProcessType", "Discrete"},    {"BrownianBridge", "True"},
                                                       {"AntitheticVariate", "False"}, {"ControlVariate", "True"},


### PR DESCRIPTION
Hi,
While going through FX Asian option pricing I noticed that the engine builders were setup to reference the `BlackScholesMerton` process as their model. To keep the FX Asians consistent with the other various FX instruments supported, I suggest the Asians be changed to denote the model as `GarmanKolhagen` rather. This would break existing pricing engine configs, but perhaps the adoption of the FX Asians is small enough to change this without adding proper deprecation flags. Would you agree with this?

See commit message for other notes, too.

Best,
Fredrik,
SEB