### PR TITLE
Corrections to docstrings and logging messages

### DIFF
--- a/OREData/ored/marketdata/equityvolcurve.cpp
+++ b/OREData/ored/marketdata/equityvolcurve.cpp
@@ -159,7 +159,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
     if (wildcard) {
         DLOG("Have single quote with pattern " << (*wildcard).regex());
 
-        // Loop over quotes and process commodity option quotes matching pattern on asof
+        // Loop over quotes and process equity option quotes matching pattern on asof
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
 
             // Go to next quote if the market data point's date does not equal our asof
@@ -193,7 +193,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
 
         DLOG("Have " << vcc.quotes().size() << " explicit quotes");
 
-        // Loop over quotes and process commodity option quotes that are explicitly specified in the config
+        // Loop over quotes and process equity option quotes that are explicitly specified in the config
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
             // Go to next quote if the market data point's date does not equal our asof
             if (md->asofDate() != asof)
@@ -571,7 +571,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
         if (md->asofDate() != asof)
             continue;
 
-        // Go to next quote if not a commodity option quote.
+        // Go to next quote if not a equity option quote.
         auto q = boost::dynamic_pointer_cast<EquityOptionQuote>(md);
         if (!q)
             continue;
@@ -806,7 +806,7 @@ void EquityVolCurve::buildVolatility(const QuantLib::Date& asof, EquityVolatilit
         if (md->asofDate() != asof)
             continue;
 
-        // Go to next quote if not a commodity option quote.
+        // Go to next quote if not a equity option quote.
         auto q = boost::dynamic_pointer_cast<EquityOptionQuote>(md);
         if (!q)
             continue;

--- a/OREData/ored/portfolio/builders/creditdefaultswapoption.hpp
+++ b/OREData/ored/portfolio/builders/creditdefaultswapoption.hpp
@@ -16,8 +16,8 @@
  FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
 */
 
-/*! \file portfolio/builders/creditdefaultswap.hpp
-\brief Builder that returns an engine to price a credit default swap
+/*! \file portfolio/builders/creditdefaultswapoption.hpp
+\brief Builder that returns an engine to price a credit default swap option
 \ingroup builders
 */
 

--- a/OREData/ored/portfolio/builders/equityfuturesoption.hpp
+++ b/OREData/ored/portfolio/builders/equityfuturesoption.hpp
@@ -28,7 +28,7 @@
 namespace ore {
 namespace data {
 
-/*! Engine builder for European commodity options
+/*! Engine builder for European equity futures options
     \ingroup builders
  */
 class EquityFutureEuropeanOptionEngineBuilder : public EuropeanForwardOptionEngineBuilder {

--- a/OREData/ored/portfolio/builders/quantoequityoption.hpp
+++ b/OREData/ored/portfolio/builders/quantoequityoption.hpp
@@ -16,8 +16,8 @@
  FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
 */
 
-/*! \file portfolio/builders/equityoption.hpp
-    \brief Engine builder for equity options
+/*! \file portfolio/builders/quantoequityoption.hpp
+    \brief Engine builder for quanto equity options
     \ingroup builders
 */
 

--- a/OREData/ored/portfolio/equityforward.hpp
+++ b/OREData/ored/portfolio/equityforward.hpp
@@ -16,8 +16,8 @@
  FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
 */
 
-/*! \file portfolio/equityoption.hpp
-\brief Equity Option data model and serialization
+/*! \file portfolio/equityforward.hpp
+\brief Equity Forward data model and serialization
 \ingroup tradedata
 */
 

--- a/OREData/ored/portfolio/equityfuturesoption.cpp
+++ b/OREData/ored/portfolio/equityfuturesoption.cpp
@@ -28,7 +28,7 @@ EquityFutureOption::EquityFutureOption(Envelope& env, OptionData option, const s
 }
 
 void EquityFutureOption::build(const boost::shared_ptr<EngineFactory>& engineFactory) {
-    QL_REQUIRE(quantity_ > 0, "Commodity option requires a positive quatity");
+    QL_REQUIRE(quantity_ > 0, "Equity futures option requires a positive quatity");
     assetName_ = name();
     // FIXME: use index once implemented
     // const boost::shared_ptr<Market>& market = engineFactory->market();

--- a/OREData/ored/portfolio/equityswap.hpp
+++ b/OREData/ored/portfolio/equityswap.hpp
@@ -30,7 +30,7 @@ namespace ore {
 namespace data {
 using std::string;
 
-//! Serializable Equity Forward contract
+//! Serializable Equity Swap contract
 /*!
 \ingroup tradedata
 */


### PR DESCRIPTION
Hi all,
Currently, many docstrings in header files refer to the wrong object which leads to confusing documentation. On the same note, there are many equity related implementations that incorrectly refer to commodity items in comments and logging messages. This PR resolves some of those issues to hopefully make the code base clearer.

Best,
Fredrik
SEB