### PR TITLE
Adding CubicSpline interpolation for delta volatility surfaces

### DIFF
--- a/Docs/UserGuide/curve_configurations/commodity_volatilities.tex
+++ b/Docs/UserGuide/curve_configurations/commodity_volatilities.tex
@@ -313,7 +313,7 @@ A comma separated list of one or more call deltas to use in the volatility surfa
 Only \lstinline!Linear! is currently supported here.
 
 \item \lstinline!StrikeInterpolation!:
-Allowable values are \lstinline!Linear!, \lstinline!NaturalCubic! and \lstinline!FinancialCubic!.
+Allowable values are \lstinline!Linear!, \lstinline!NaturalCubic!, \lstinline!FinancialCubic! and \lstinline!CubicSpline!.
 
 \item \lstinline!Extrapolation!:
 A boolean value indicating if extrapolation is allowed.

--- a/OREData/ored/marketdata/commodityvolcurve.cpp
+++ b/OREData/ored/marketdata/commodityvolcurve.cpp
@@ -1025,6 +1025,8 @@ void CommodityVolCurve::buildVolatility(const Date& asof, CommodityVolatilityCon
         im = InterpolatedSmileSection::InterpolationMethod::NaturalCubic;
     } else if (vdsc.strikeInterpolation() == "FinancialCubic") {
         im = InterpolatedSmileSection::InterpolationMethod::FinancialCubic;
+    } else if (vdsc.strikeInterpolation() == "CubicSpline") {
+        im = InterpolatedSmileSection::InterpolationMethod::CubicSpline;
     } else {
         im = InterpolatedSmileSection::InterpolationMethod::Linear;
         DLOG("BlackVolatilitySurfaceDelta does not support strike interpolation '" << vdsc.strikeInterpolation()

--- a/OREData/ored/marketdata/equityvolcurve.cpp
+++ b/OREData/ored/marketdata/equityvolcurve.cpp
@@ -942,6 +942,8 @@ void EquityVolCurve::buildVolatility(const QuantLib::Date& asof, EquityVolatilit
         im = InterpolatedSmileSection::InterpolationMethod::NaturalCubic;
     } else if (vdsc.strikeInterpolation() == "FinancialCubic") {
         im = InterpolatedSmileSection::InterpolationMethod::FinancialCubic;
+    } else if (vdsc.strikeInterpolation() == "CubicSpline") {
+        im = InterpolatedSmileSection::InterpolationMethod::CubicSpline;
     } else {
         im = InterpolatedSmileSection::InterpolationMethod::Linear;
         DLOG("BlackVolatilitySurfaceDelta does not support strike interpolation '" << vdsc.strikeInterpolation()

--- a/QuantExt/qle/termstructures/blackvolsurfacedelta.cpp
+++ b/QuantExt/qle/termstructures/blackvolsurfacedelta.cpp
@@ -42,6 +42,8 @@ InterpolatedSmileSection::InterpolatedSmileSection(Real spot, Real rd, Real rf, 
         interpolator_ = Cubic(CubicInterpolation::Kruger, true, CubicInterpolation::SecondDerivative, 0.0,
                               CubicInterpolation::FirstDerivative)
                             .interpolate(strikes_.begin(), strikes_.end(), vols_.begin());
+    else if (method == InterpolationMethod::CubicSpline)
+        interpolator_ = CubicNaturalSpline(strikes_.begin(), strikes_.end(), vols_.begin());
     else {
         QL_FAIL("Invalid method " << (int)method);
     }

--- a/QuantExt/qle/termstructures/blackvolsurfacedelta.hpp
+++ b/QuantExt/qle/termstructures/blackvolsurfacedelta.hpp
@@ -40,7 +40,7 @@ using namespace QuantLib;
 class InterpolatedSmileSection : public FxSmileSection {
 public:
     //! Supported interpolation methods
-    enum class InterpolationMethod { Linear, NaturalCubic, FinancialCubic };
+    enum class InterpolationMethod { Linear, NaturalCubic, FinancialCubic, CubicSpline };
 
     //! ctor
     InterpolatedSmileSection(Real spot, Real rd, Real rf, Time t, const std::vector<Real>& strikes,

--- a/QuantExt/test/blackvolsurfacedelta.cpp
+++ b/QuantExt/test/blackvolsurfacedelta.cpp
@@ -70,6 +70,33 @@ BOOST_AUTO_TEST_CASE(testBlackVolSurfaceDeltaConstantVol) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testInterpolatedSmileSectionConstruction) {
+
+    BOOST_TEST_MESSAGE("Testing QuantExt::InterpolatedSmileSection...");
+    // Set up the parameters with some arbitrary data
+    Real spot = 100;
+    Real rd = 0.05;
+    Real rf = 0.03;
+    Time t = 1.0;
+    vector<Real> strikes = { 90, 100, 110 };
+    vector<Volatility> vols = { 0.15, 0.1, 0.15 };
+    vector<InterpolatedSmileSection::InterpolationMethod> methods = {
+        InterpolatedSmileSection::InterpolationMethod::Linear,
+        InterpolatedSmileSection::InterpolationMethod::FinancialCubic,
+        InterpolatedSmileSection::InterpolationMethod::NaturalCubic,
+        InterpolatedSmileSection::InterpolationMethod::CubicSpline
+    };
+
+    // Construct the smile section
+    boost::shared_ptr<InterpolatedSmileSection> section;
+    for (auto method : methods) {
+        BOOST_TEST_MESSAGE("Trying to construct InterpolatedSmileSection with interpolation method: " << method << ".");
+        BOOST_CHECK_NO_THROW(section =
+                                 boost::make_shared<InterpolatedSmileSection>(spot, rd, rf, t, strikes, vols, method));
+        BOOST_CHECK_EQUAL(section->volatility(strikes.at(1)), vols.at(1));
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/xsd/ore_types.xsd
+++ b/xsd/ore_types.xsd
@@ -441,6 +441,7 @@
       <xs:enumeration value="NelsonSiegel"/>
       <xs:enumeration value="Svensson"/>
       <xs:enumeration value="BackwardFlat"/>
+      <xs:enumeration value="CubicSpline"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Hi,
This adds a mapping for CubicSpline (natural) interpolation for use in equity and commodity delta volatility surface configurations. Also adds it to the XSD, which was also done in #79 but for other reasons. I also noted down the option in the commodity volatility documentation, though I couldn't do so for the equity delta surface as it has no documentation for the time being.

Adds a unit test for the `InterpolatedSmileSection` class to ensure it constructs correctly given different interpolation methods. 

I guess there are a few things to remark on;
- Someone might want to give input on the naming of the method in the config and whether it should enforce "monotonic" interpolation by default...
- There should probably be a standardized parser for the strike interpolation method (for delta surfaces), to reduce code duplication between the equity and commodity implementations.

Best,
Fredrik
SEB