### PR TITLE
Adding Asian option XSDs

### DIFF
--- a/xsd/instruments.xsd
+++ b/xsd/instruments.xsd
@@ -498,7 +498,7 @@
       <xs:all>
         <xs:element type="xs:float" name="Quantity" minOccurs="0" maxOccurs="1"/>
         <xs:element type="xs:string" name="ReturnType" minOccurs="1" maxOccurs="1"/>
-        <xs:element ref="equityNameType"/>
+        <xs:element ref="underlyingNameType"/>
         <xs:element type="xs:float" name="InitialPrice" minOccurs="0" maxOccurs="1"/>
         <xs:element type="extendedCurrencyCode" name="InitialPriceCurrency" minOccurs="0" maxOccurs="1"/>
         <xs:element type="xs:float" name="DividendFactor" minOccurs="0" maxOccurs="1"/>
@@ -803,7 +803,7 @@
   <xs:complexType name="equityOptionData">
     <xs:all>
       <xs:element type="optionData" name="OptionData"/>
-      <xs:element ref="equityNameType"/>
+      <xs:element ref="underlyingNameType"/>
       <xs:element type="extendedCurrencyCode" name="Currency"/>
       <xs:element type="xs:float" name="Strike"/>
       <xs:element type="extendedCurrencyCode" name="StrikeCurrency" minOccurs="0"/>
@@ -814,7 +814,7 @@
   <xs:complexType name="equityFutureOptionData">
     <xs:all>
       <xs:element type="optionData" name="OptionData"/>
-      <xs:element ref="equityNameType"/>
+      <xs:element ref="underlyingNameType"/>
       <xs:element type="currencyCode" name="Currency"/>
       <xs:element type="xs:float" name="Strike"/>
       <xs:element type="xs:float" name="Quantity"/>
@@ -838,7 +838,7 @@
     <xs:all>
       <xs:element type="longShort" name="LongShort"/>
       <xs:element type="date" name="Maturity"/>
-      <xs:element ref="equityNameType"/>
+      <xs:element ref="underlyingNameType"/>
       <xs:element type="extendedCurrencyCode" name="Currency"/>
       <xs:element type="xs:float" name="Strike"/>
       <xs:element type="extendedCurrencyCode" name="StrikeCurrency" minOccurs="0"/>
@@ -1002,8 +1002,8 @@
     </xs:all>
   </xs:complexType>
   
-  <xs:element name="equityNameType" abstract="true"/>
-  <xs:element type="xs:string" name="Name" substitutionGroup="equityNameType"/>
-  <xs:element type= "underlying" name="Underlying" substitutionGroup="equityNameType"/>
+  <xs:element name="underlyingNameType" abstract="true"/>
+  <xs:element type="xs:string" name="Name" substitutionGroup="underlyingNameType" />
+  <xs:element type="underlying" name="Underlying" substitutionGroup="underlyingNameType"/>
 
 </xs:schema>

--- a/xsd/instruments.xsd
+++ b/xsd/instruments.xsd
@@ -31,10 +31,12 @@
       <xs:element type="swapData" name="EquitySwapData"/>
       <xs:element type="swaptionData" name="SwaptionData"/>
       <xs:element type="forwardRateAgreementData" name="ForwardRateAgreementData"/>
+      <xs:element type="fxAsianOptionData" name="FxAsianOptionData"/>
       <xs:element type="fxForwardData" name="FxForwardData"/>
       <xs:element type="fxOptionData" name="FxOptionData"/>
       <xs:element type="fxSwapData" name="FxSwapData"/>
       <xs:element type="capFloorData" name="CapFloorData"/>
+      <xs:element type="equityAsianOptionData" name="EquityAsianOptionData"/>
       <xs:element type="equityFutureOptionData" name="EquityFutureOptionData"/>
       <xs:element type="equityOptionData" name="EquityOptionData"/>
       <xs:element type="equityForwardData" name="EquityForwardData"/>
@@ -43,6 +45,7 @@
       <xs:element type="forwardBondData" name="ForwardBondData"/>
       <xs:element type="creditDefaultSwapData" name="CreditDefaultSwapData"/>
       <xs:element type="creditDefaultSwapOptionData" name="CreditDefaultSwapOptionData"/>
+      <xs:element type="commodityAsianOptionData" name="CommodityAsianOptionData"/>
       <xs:element type="commodityOptionData" name="CommodityOptionData"/>
     </xs:choice>
   </xs:group>
@@ -656,14 +659,17 @@
       <xs:enumeration value="ForwardRateAgreement"/>
       <xs:enumeration value="FxForward"/>
       <xs:enumeration value="FxOption"/>
+      <xs:enumeration value="FxAsianOption"/>
       <xs:enumeration value="FxSwap"/>
       <xs:enumeration value="CapFloor"/>
       <xs:enumeration value="EquityOption"/>
       <xs:enumeration value="EquityFutureOption"/>
+      <xs:enumeration value="EquityAsianOption"/>
       <xs:enumeration value="EquityForward"/>
       <xs:enumeration value="EquitySwap"/>
       <xs:enumeration value="CommodityForward"/>
       <xs:enumeration value="CommodityOption"/>
+      <xs:enumeration value="CommodityAsianOption"/>
       <xs:enumeration value="Bond"/>
       <xs:enumeration value="ForwardBond"/>
       <xs:enumeration value="CreditDefaultSwap"/>
@@ -759,6 +765,19 @@
     </xs:all>
   </xs:complexType>
 
+  <xs:complexType name="fxAsianOptionData">
+    <xs:all>
+      <xs:element type="optionData" name="OptionData"/>
+      <xs:element type="asianData" name="AsianData"/>
+      <xs:element type="scheduleData" name="ObservationDates"/>
+      <xs:element type="currencyCode" name="BoughtCurrency"/>
+      <xs:element type="xs:float" name="BoughtAmount"/>
+      <xs:element type="currencyCode" name="SoldCurrency"/>
+      <xs:element type="xs:float" name="SoldAmount"/>
+      <xs:element type="xs:string" name="FXIndex"/>
+    </xs:all>
+  </xs:complexType>
+
   <xs:complexType name="capFloorData">
     <xs:sequence>
       <xs:element type="longShort" name="LongShort"/>
@@ -822,10 +841,36 @@
     </xs:all>
   </xs:complexType>
 
+  <xs:complexType name="equityAsianOptionData">
+    <xs:all>
+      <xs:element type="optionData" name="OptionData"/>
+      <xs:element type="asianData" name="AsianData"/>
+      <xs:element type="scheduleData" name="ObservationDates"/>
+      <xs:element ref="underlyingNameType"/>
+      <xs:element type="extendedCurrencyCode" name="Currency"/>
+      <xs:element type="xs:float" name="Strike"/>
+      <xs:element type="xs:float" name="Quantity"/>
+    </xs:all>
+  </xs:complexType>
+
   <xs:complexType name="commodityOptionData">
     <xs:all>
       <xs:element type="optionData" name="OptionData"/>
       <xs:element type="xs:string" name="Name"/>
+      <xs:element type="currencyCode" name="Currency"/>
+      <xs:element type="xs:float" name="Strike"/>
+      <xs:element type="xs:float" name="Quantity"/>
+      <xs:element type="bool" name="IsFuturePrice" minOccurs="0"/>
+      <xs:element type="date" name="FutureExpiryDate" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="commodityAsianOptionData">
+    <xs:all>
+      <xs:element type="optionData" name="OptionData"/>
+      <xs:element type="asianData" name="AsianData"/>
+      <xs:element type="scheduleData" name="ObservationDates"/>
+      <xs:element ref="underlyingNameType"/>
       <xs:element type="currencyCode" name="Currency"/>
       <xs:element type="xs:float" name="Strike"/>
       <xs:element type="xs:float" name="Quantity"/>


### PR DESCRIPTION
Hi all,
We've finally gotten around to adding the XSDs for Asian equity, FX, and commodity options. I've tried to verify the schemas on my end but if you spot any problems, let me know and I'll have a look. I also renamed the equity node for Name vs Underlying so that it can be reused across both equities and commodities.

I should note that I have not covered the "scripted flavor" format for FX Asians (which you added last year), i.e. only the "vanilla flavor", so perhaps you want to give input regarding that.

Best regards,
Fredrik
SEB