### PR TITLE
Map TW engine for arithmetic average price options

### DIFF
--- a/OREData/ored/portfolio/builders/asianoption.hpp
+++ b/OREData/ored/portfolio/builders/asianoption.hpp
@@ -32,6 +32,7 @@
  #include <ql/pricingengines/asian/analytic_discr_geom_av_strike.hpp>
  #include <ql/pricingengines/asian/mc_discr_arith_av_price.hpp>
  #include <ql/pricingengines/asian/mc_discr_arith_av_strike.hpp>
+ #include <ql/pricingengines/asian/turnbullwakemanasianengine.hpp>
  #include <ql/utilities/null.hpp>
 
  namespace ore {
@@ -260,6 +261,28 @@
          boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
              getBlackScholesProcess(assetName, ccy, assetClassUnderlying);
          return boost::make_shared<AnalyticContinuousGeometricAveragePriceAsianEngine>(gbsp);
+     }
+ };
+
+ //! Discrete Analytic TW Engine Builder for European Asian Arithmetic Average Price Options
+ /*! Pricing engines are cached by asset/currency
+     \ingroup builders
+  */
+ class EuropeanAsianOptionTWEngineBuilder : public AsianOptionEngineBuilder {
+ public:
+     EuropeanAsianOptionTWEngineBuilder(const string& model, const set<string>& tradeTypes,
+                                        const AssetClass& assetClass)
+         : AsianOptionEngineBuilder(model, "TurnbullWakemanAsianEngine", tradeTypes, assetClass, Date()) {}
+
+     std::string processType() override { return "Discrete"; }
+
+ protected:
+     virtual boost::shared_ptr<PricingEngine> engineImpl(const string& assetName, const Currency& ccy,
+                                                         const AssetClass& assetClassUnderlying,
+                                                         const Date& expiryDate) override {
+         boost::shared_ptr<GeneralizedBlackScholesProcess> gbsp =
+             getBlackScholesProcess(assetName, ccy, assetClassUnderlying);
+         return boost::make_shared<TurnbullWakemanAsianEngine>(gbsp);
      }
  };
 

--- a/OREData/ored/portfolio/builders/commodityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/commodityasianoption.hpp
@@ -94,5 +94,16 @@
                                                  AssetClass::COM) {}
  };
 
+ //! Discrete Analytic TW Engine Builder for European Asian Commodity Arithmetic Average Price Options
+ /*! Pricing engines are cached by asset/currency
+     \ingroup builders
+  */
+ class CommodityEuropeanAsianOptionTWEngineBuilder : public EuropeanAsianOptionTWEngineBuilder {
+ public:
+     CommodityEuropeanAsianOptionTWEngineBuilder()
+         : EuropeanAsianOptionTWEngineBuilder("BlackScholesMerton", {"CommodityAsianOptionArithmeticPrice"},
+                                              AssetClass::COM) {}
+ };
+
  } // namespace data
  } // namespace ore

--- a/OREData/ored/portfolio/builders/equityasianoption.hpp
+++ b/OREData/ored/portfolio/builders/equityasianoption.hpp
@@ -94,5 +94,16 @@
                                                  AssetClass::EQ) {}
  };
 
+ //! Discrete Analytic TW Engine Builder for European Asian Equity Arithmetic Average Price Options
+ /*! Pricing engines are cached by asset/currency
+     \ingroup builders
+  */
+ class EquityEuropeanAsianOptionTWEngineBuilder : public EuropeanAsianOptionTWEngineBuilder {
+ public:
+     EquityEuropeanAsianOptionTWEngineBuilder()
+         : EuropeanAsianOptionTWEngineBuilder("BlackScholesMerton", {"EquityAsianOptionArithmeticPrice"},
+                                              AssetClass::EQ) {}
+ };
+
  } // namespace data
  } // namespace ore

--- a/OREData/ored/portfolio/builders/fxasianoption.hpp
+++ b/OREData/ored/portfolio/builders/fxasianoption.hpp
@@ -94,5 +94,15 @@
      }
  };
 
+ //! Discrete Analytic TW Engine Builder for European Asian Fx Arithmetic Average Price Options
+ /*! Pricing engines are cached by asset/currency
+     \ingroup builders
+  */
+ class FxEuropeanAsianOptionTWEngineBuilder : public EuropeanAsianOptionTWEngineBuilder {
+ public:
+     FxEuropeanAsianOptionTWEngineBuilder()
+         : EuropeanAsianOptionTWEngineBuilder("GarmanKohlhagen", {"FxAsianOptionArithmeticPrice"}, AssetClass::FX) {}
+ };
+
  } // namespace data
  } // namespace ore

--- a/OREData/ored/portfolio/enginefactory.cpp
+++ b/OREData/ored/portfolio/enginefactory.cpp
@@ -172,7 +172,8 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<FxEuropeanAsianOptionACGAPEngineBuilder>());
     registerBuilder(boost::make_shared<FxEuropeanAsianOptionADGAPEngineBuilder>());
     registerBuilder(boost::make_shared<FxEuropeanAsianOptionADGASEngineBuilder>());
-     
+    registerBuilder(boost::make_shared<FxEuropeanAsianOptionTWEngineBuilder>());
+
     registerBuilder(boost::make_shared<CapFloorEngineBuilder>());
     registerBuilder(boost::make_shared<CapFlooredIborLegEngineBuilder>());
     registerBuilder(boost::make_shared<CapFlooredOvernightIndexedCouponLegEngineBuilder>());
@@ -197,6 +198,7 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<EquityEuropeanAsianOptionACGAPEngineBuilder>());
     registerBuilder(boost::make_shared<EquityEuropeanAsianOptionADGAPEngineBuilder>());
     registerBuilder(boost::make_shared<EquityEuropeanAsianOptionADGASEngineBuilder>());
+    registerBuilder(boost::make_shared<EquityEuropeanAsianOptionTWEngineBuilder>());
     registerBuilder(boost::make_shared<EquityFutureEuropeanOptionEngineBuilder>());
 
     registerBuilder(boost::make_shared<BondDiscountingEngineBuilder>());
@@ -221,6 +223,7 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionACGAPEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionADGAPEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionADGASEngineBuilder>());
+    registerBuilder(boost::make_shared<CommodityEuropeanAsianOptionTWEngineBuilder>());
     registerBuilder(boost::make_shared<QuantoEquityEuropeanOptionEngineBuilder>());
 
     registerLegBuilder(boost::make_shared<DurationAdjustedCmsLegBuilder>());


### PR DESCRIPTION
Hi there,
We have recently PR'd the Turnbull-Wakeman moment-matching engine to QL, available to be used when pricing Asian options in ORE. We have used it successfully on our end and hopefully you might have some interest in it as well.

Notably, the engine will be available with QL 1.27 so previous build may fail until ORE is updated to run v1.27 (or later versions). Hopefully this may happen with ORE 7? :) If not, we could add preprocessor directives to conditionally include the engine if the QL version is recent enough.


Best,
Fredrik
SEB