### PR TITLE
Move portfolio and builder files to correct filters

### DIFF
--- a/OREData/OREData.vcxproj.filters
+++ b/OREData/OREData.vcxproj.filters
@@ -759,9 +759,6 @@
     <ClCompile Include="ored\portfolio\equityfxlegdata.cpp">
       <Filter>portfolio</Filter>
     </ClCompile>
-    <ClInclude Include="ored\portfolio\builders\fxbarrieroption.hpp">
-      <Filter>portfolio</Filter>
-    </ClInclude>
     <ClInclude Include="ored\portfolio\fxbarrieroption.hpp">
       <Filter>portfolio</Filter>
     </ClInclude>
@@ -783,9 +780,6 @@
     <ClInclude Include="ored\portfolio\fxkikobarrieroption.hpp">
       <Filter>portfolio</Filter>
     </ClInclude>
-    <ClInclude Include="ored\portfolio\builders\fxtouchoption.hpp">
-      <Filter>portfolio</Filter>
-    </ClInclude>
     <ClInclude Include="ored\portfolio\types.hpp">
       <Filter>marketdata</Filter>
     </ClInclude>
@@ -802,9 +796,6 @@
       <Filter>portfolio\builders</Filter>
     </ClInclude>
     <ClInclude Include="ored\portfolio\builders\fxdoublebarrieroption.hpp">
-      <Filter>portfolio\builders</Filter>
-    </ClInclude>
-    <ClInclude Include="ored\portfolio\fxtouchoption.hpp">
       <Filter>portfolio\builders</Filter>
     </ClInclude>
     <ClInclude Include="ored\portfolio\builders\fxdigitalbarrieroption.hpp">
@@ -875,6 +866,15 @@
     </ClInclude>
     <ClInclude Include="ored\portfolio\multilegoption.hpp">
       <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\fxtouchoption.hpp">
+      <Filter>portfolio</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\fxtouchoption.hpp">
+      <Filter>portfolio\builders</Filter>
+    </ClInclude>
+    <ClInclude Include="ored\portfolio\builders\fxbarrieroption.hpp">
+      <Filter>portfolio\builders</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1026,9 +1026,6 @@
       <Filter>portfolio</Filter>
     </ClCompile>
     <ClCompile Include="ored\portfolio\commodityswaption.cpp">
-      <Filter>portfolio</Filter>
-    </ClCompile>
-    <ClCompile Include="ored\portfolio\builders\commodityapomodelbuilder.cpp">
       <Filter>portfolio</Filter>
     </ClCompile>
     <ClCompile Include="ored\portfolio\failedtrade.cpp">
@@ -1526,6 +1523,9 @@
     </ClCompile>
     <ClCompile Include="ored\portfolio\multilegoption.cpp">
       <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\builders\commodityapomodelbuilder.cpp">
+      <Filter>portfolio\builders</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi!
This corrects the filters for some files under _ored/portfolio_ in the latest release. Affects:
- _portfolio/fxbarrieroption.hpp_ and _portfolio/builders/fxbarrieroption.hpp_
- _portfolio/fxtouchoption.hpp_ and _portfolio/builders/fxtouchoption.hpp_
- _builders/commodityapomodelbuilder.cpp_

Let me know if something looks off or if it's already waiting to be released!