### PR TITLE
Apply payment lag for CPI and Zero Coupon Fixed legs

### DIFF
--- a/Docs/UserGuide/tradecomponents/legdatanotionals.tex
+++ b/Docs/UserGuide/tradecomponents/legdatanotionals.tex
@@ -52,7 +52,7 @@ Allowable values:  \emph{true, false}
 
 Allowable values:  See Table \ref{tab:currency} \lstinline!Currency!. When \lstinline!LegType! is \emph{Equity}, Minor Currencies in Table \ref{tab:currency} are also allowable.
 
-\item PaymentCalendar [Optional]: The payment calendar of the leg coupons. The \lstinline!PaymentCalendar! is used in conjuction with the \lstinline!PaymentConvention! and the \lstinline!PaymentLag! to determine the payments dates, unless the \lstinline!PaymentDates! node is used which defines the payment dates explicitly.
+\item PaymentCalendar [Optional]: The payment calendar of the leg coupons. The \lstinline!PaymentCalendar! is used in conjunction with the \lstinline!PaymentConvention! and the \lstinline!PaymentLag! to determine the payments dates, unless the \lstinline!PaymentDates! node is used which defines the payment dates explicitly.
 
 Allowable values: See Table \ref{tab:calendar} \lstinline!Calendar!. If left blank or omitted, defaults to the calendar in the \lstinline!ScheduleData! node, unless \lstinline!LegType! is \emph{Floating} and \lstinline!Index! is OIS, in which case this defaults to the index calendar. 
 
@@ -62,7 +62,7 @@ The \lstinline!PaymentCalendar! calendar field is currently only supported for \
 
 Allowable values: See Table \ref{tab:convention}.
 
-\item PaymentLag [optional]: The payment lag applies to Fixed legs, Equity legs, and Floating legs with Ibor and OIS indices (but not to BMA/SIFMA indices). \\
+\item PaymentLag [optional]: The payment lag applies to Fixed legs, Equity legs, and Floating legs with Ibor and OIS indices (but not to BMA/SIFMA indices), as well as CPI legs and Zero Coupon Fixed legs. \\
 PaymentLag is also not supported for CapFloor Floating legs that have Ibor coupons with sub periods (HasSubPeriods = \emph{true}), nor for CapFloor Floating legs with averaged ON coupons (IsAveraged = \emph{true}).
 
 Allowable values: Any valid period, i.e. a non-negative whole number, optionally followed by \emph{D} (days), \emph{W} (weeks), \emph{M} (months),

--- a/OREData/ored/portfolio/legdata.cpp
+++ b/OREData/ored/portfolio/legdata.cpp
@@ -1662,6 +1662,7 @@ Leg makeCPILeg(const LegData& data, const boost::shared_ptr<ZeroInflationIndex>&
     bool finalFlowCapFloor = cpiLegData->finalFlowCap() != Null<Real>() || cpiLegData->finalFlowFloor() != Null<Real>();
 
     applyAmortization(notionals, data, schedule, false);
+    PaymentLag paymentLag = parsePaymentLag(data.paymentLag());
 
     QuantExt::CPILeg cpiLeg =
         QuantExt::CPILeg(schedule, index,
@@ -1672,6 +1673,7 @@ Leg makeCPILeg(const LegData& data, const boost::shared_ptr<ZeroInflationIndex>&
             .withPaymentDayCounter(dc)
             .withPaymentAdjustment(bdc)
             .withPaymentCalendar(paymentCalendar)
+            .withPaymentLag(boost::apply_visitor(PaymentLagInteger(), paymentLag))
             .withFixedRates(rates)
             .withObservationInterpolation(interpolationMethod)
             .withSubtractInflationNominal(cpiLegData->subtractInflationNominal())

--- a/OREData/ored/portfolio/legdata.cpp
+++ b/OREData/ored/portfolio/legdata.cpp
@@ -1057,6 +1057,8 @@ Leg makeZCFixedLeg(const LegData& data, const QuantLib::Date& openEndDateReplace
         paymentCalendar = parseCalendar(data.paymentCalendar());
 
     BusinessDayConvention payConvention = parseBusinessDayConvention(data.paymentConvention());
+    PaymentLag paymentLag = parsePaymentLag(data.paymentLag());
+    Natural paymentLagDays = boost::apply_visitor(PaymentLagInteger(), paymentLag);
 
     DayCounter dc = parseDayCounter(data.dayCounter());
 
@@ -1087,7 +1089,7 @@ Leg makeZCFixedLeg(const LegData& data, const QuantLib::Date& openEndDateReplace
         double currentNotional = i < notionals.size() ? notionals[i] : notionals.back();
         double currentRate = i < rates.size() ? rates[i] : rates.back();
         cpnDates.push_back(dates[i + 1]);
-        Date paymentDate = paymentCalendar.adjust(dates[i + 1], payConvention);
+        Date paymentDate = paymentCalendar.advance(dates[i + 1], paymentLagDays, Days, payConvention);
         leg.push_back(boost::make_shared<ZeroFixedCoupon>(paymentDate, currentNotional, currentRate, dc, cpnDates, comp,
                                                           zcFixedLegData->subtractNotional()));
     }

--- a/QuantExt/qle/cashflows/cpicoupon.cpp
+++ b/QuantExt/qle/cashflows/cpicoupon.cpp
@@ -277,6 +277,11 @@ CPILeg& CPILeg::withPaymentCalendar(const Calendar& cal) {
     return *this;
 }
 
+CPILeg& CPILeg::withPaymentLag(Natural lag) {
+    paymentLag_ = lag;
+    return *this;
+}
+
 CPILeg& CPILeg::withFixingDays(Natural fixingDays) {
     fixingDays_ = std::vector<Natural>(1, fixingDays);
     return *this;
@@ -366,7 +371,7 @@ CPILeg::operator Leg() const {
         for (Size i = 0; i < n; ++i) {
             refStart = start = schedule_.date(i);
             refEnd = end = schedule_.date(i + 1);
-            Date paymentDate = paymentCalendar_.adjust(end, paymentAdjustment_);
+            Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
 
             Date exCouponDate;
             if (exCouponPeriod_ != Period()) {
@@ -405,10 +410,13 @@ CPILeg::operator Leg() const {
     }
 
     // in CPI legs you always have a notional flow of some sort
-    Date paymentDate = paymentCalendar_.adjust(schedule_.date(n), paymentAdjustment_);
     
+    // Previous implementations didn't differentiate the observation and payment dates
+    Date observationDate = paymentCalendar_.adjust(schedule_.date(n), paymentAdjustment_);
+    Date paymentDate = paymentCalendar_.advance(schedule_.date(n), paymentLag_, Days, paymentAdjustment_);
+
     ext::shared_ptr<CPICashFlow> xnl = ext::make_shared<CPICashFlow>(
-        detail::get(notionals_, n, 0.0), index_, baseDate, baseCPI_, paymentDate, observationLag_,
+        detail::get(notionals_, n, 0.0), index_, baseDate, baseCPI_, observationDate, observationLag_,
         observationInterpolation_, paymentDate, subtractInflationNominal_);
 
     if (finalFlowCap_ == Null<Real>() && finalFlowFloor_ == Null<Real>()) {

--- a/QuantExt/qle/cashflows/cpicoupon.hpp
+++ b/QuantExt/qle/cashflows/cpicoupon.hpp
@@ -146,6 +146,7 @@ public:
     CPILeg& withPaymentDayCounter(const DayCounter&);
     CPILeg& withPaymentAdjustment(BusinessDayConvention);
     CPILeg& withPaymentCalendar(const Calendar&);
+    CPILeg& withPaymentLag(Natural lag);
     CPILeg& withFixingDays(Natural fixingDays);
     CPILeg& withFixingDays(const std::vector<Natural>& fixingDays);
     CPILeg& withObservationInterpolation(CPI::InterpolationType);
@@ -176,6 +177,7 @@ private:
     DayCounter paymentDayCounter_;
     BusinessDayConvention paymentAdjustment_;
     Calendar paymentCalendar_;
+    Natural paymentLag_;
     std::vector<Natural> fixingDays_;
     CPI::InterpolationType observationInterpolation_;
     bool subtractInflationNominal_;

--- a/QuantExt/test/CMakeLists.txt
+++ b/QuantExt/test/CMakeLists.txt
@@ -22,6 +22,7 @@ commodityspreadoption.cpp
 computeenvironment.cpp
 correlationtermstructure.cpp
 cpicapfloor.cpp
+cpileg.cpp
 crcirpp.cpp
 crossassetmodel.cpp
 crossassetmodel2.cpp

--- a/QuantExt/test/cpileg.cpp
+++ b/QuantExt/test/cpileg.cpp
@@ -1,0 +1,74 @@
+/*
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include <boost/test/unit_test.hpp>
+#include <ql/indexes/inflation/ukrpi.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/all.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <qle/cashflows/cpicoupon.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+BOOST_FIXTURE_TEST_SUITE(QuantExtTestSuite, qle::test::TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(CpiLegTest)
+
+BOOST_AUTO_TEST_CASE(testCpiLegPaymentLag) {
+
+    BOOST_TEST_MESSAGE("Testing QuantExt::CPILeg for payment lag...");
+
+    Date evaluationDate(6, October, 2023);
+    Settings::instance().evaluationDate() = evaluationDate;
+    Calendar calendar = WeekendsOnly();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
+
+    Date startDate(6, October, 2023);
+    Date endDate(6, October, 2026);
+    Schedule fixedSchedule = MakeSchedule()
+                                 .from(startDate)
+                                 .to(endDate)
+                                 .withTenor(Period(6, Months))
+                                 .withCalendar(calendar)
+                                 .withConvention(ModifiedFollowing)
+                                 .backwards();
+
+    auto flatYts = ext::shared_ptr<YieldTermStructure>(new FlatForward(evaluationDate, 0.025, dayCounter));
+    RelinkableHandle<YieldTermStructure> yTS(flatYts);
+
+    auto ukrpi = ext::make_shared<UKRPI>();
+    Leg cpiLeg = QuantExt::CPILeg(fixedSchedule, ukrpi, yTS, 100, Period(3, Months))
+                     .withNotionals(1e6)
+                     .withPaymentCalendar(calendar)
+                     .withPaymentLag(2);
+
+    for (auto& coupon : cpiLeg) {
+        if (auto cpiCoupon = ext::dynamic_pointer_cast<CPICoupon>(coupon))
+            // The setup leg will have six regular coupons
+            BOOST_CHECK_EQUAL(cpiCoupon->date(), cpiCoupon->accrualEndDate() + 2 * Days);
+        else if (auto cpiNotionalCashflow = ext::dynamic_pointer_cast<CPICashFlow>(coupon))
+            // and one of these flows
+            BOOST_CHECK_EQUAL(cpiNotionalCashflow->date(), fixedSchedule.endDate() + 2 * Days);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Hi,
We price inflation swaps/bonds using these two legs types and we see quite a big valuation impact by the lack of payment lag. This PR makes use of the PaymentLag field and adjusts the relevant payment dates accordingly.

A test is added for the CPI leg case, and the user guide is updated to mention the added support.