### PR TITLE
Enable usage of wildcard quote for direct yield curve segments

### DIFF
--- a/Docs/UserGuide/curve_configurations/yieldcurves.tex
+++ b/Docs/UserGuide/curve_configurations/yieldcurves.tex
@@ -121,6 +121,11 @@ contains an ID pointing to a line in the {\tt market.txt} file, i.e.\ in this ca
 or discount factor. The \lstinline!Conventions! node contains the ID of a node in the {\tt conventions.xml} file
 described in section \ref{sec:conventions}. The \lstinline!Conventions! node associates conventions with the quotes.
 
+For \emph{Discount} type segments, the quotes can be given using a wildcard. Any valid and matching quotes will then be loaded from the provided market data. An example wildcard is:
+\begin{itemize}
+  \item {DISCOUNT/RATE/EUR/EUR3M/*}
+\end{itemize}
+
 \begin{listing}[H]
 %\hrule\medskip
 \begin{minted}[fontsize=\footnotesize]{xml}

--- a/Docs/UserGuide/marketdata.tex
+++ b/Docs/UserGuide/marketdata.tex
@@ -144,7 +144,7 @@ Bear in mind, only zero conventions (see Listing \ref{lst:zero_conventions_tenor
 Examples with a Term and with a DiscountDate:
 \begin{itemize}
 \item {DISCOUNT/RATE/EUR/EUR3M/3Y}
-\item {DISCOUNT/RATE/EUR/EUR3M/A365F/12-05-2018}
+\item {DISCOUNT/RATE/EUR/EUR3M/12-05-2018}
 \end{itemize}
 
 %- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -948,8 +948,14 @@ void YieldCurve::buildDiscountCurve() {
         }
     }
 
+    // Some logging and checks
     QL_REQUIRE(data.size() > 0, "No market data found for curve spec " << curveSpec_.name() << " with as of date "
                                                                        << io::iso_date(asofDate_));
+    if (!wildcard) {
+        QL_REQUIRE(data.size() == quotes.size(), "Found " << data.size() << " quotes, but "
+                                                          << quotes.size()
+                                                          << " quotes given in config " << curveConfig_->curveID());
+    }
 
     if (data.begin()->first > asofDate_) {
         DLOG("Insert discount curve point at time zero for " << curveSpec_.name());

--- a/OREData/test/yieldcurve.cpp
+++ b/OREData/test/yieldcurve.cpp
@@ -246,6 +246,70 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixings) {
     BOOST_CHECK_NO_THROW(YieldCurve jpyYieldCurve(asof, spec, curveConfigs, loader));
 }
 
+BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYc) {
+
+    Date asof(13, October, 2023);
+    Settings::instance().evaluationDate() = asof;
+
+    YieldCurveSpec spec("EUR", "EUR-CURVE");
+
+    CurveConfigurations curveConfigs;
+
+    vector<string> quotes;
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14");
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15");
+
+    vector<boost::shared_ptr<YieldCurveSegment>> segments{boost::make_shared<DirectYieldCurveSegment>(
+        "Discount", "", quotes)};
+
+    boost::shared_ptr<YieldCurveConfig> yCConfig =
+        boost::make_shared<YieldCurveConfig>("EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
+    curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
+
+    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE_2023-10-12/2023-10-13 0.77",
+                        "2023-10-12 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-12/2023-10-12 0.88",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-13 1.0",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14 0.99",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15 0.98",
+                        "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-10-31 1158.8",
+                        "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-11-01 1160.9",
+                        "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-11-02 1163.4"};
+    MarketDataLoader loader(data);
+
+    BOOST_CHECK_NO_THROW(YieldCurve yieldCurve(asof, spec, curveConfigs, loader));
+}
+
+BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYcWildChar) {
+
+    Date asof(13, October, 2023);
+    Settings::instance().evaluationDate() = asof;
+
+    YieldCurveSpec spec("EUR", "EUR-CURVE");
+
+    CurveConfigurations curveConfigs;
+
+    vector<string> quotes;
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/*");
+
+    vector<boost::shared_ptr<YieldCurveSegment>> segments{
+        boost::make_shared<DirectYieldCurveSegment>("Discount", "", quotes)};
+
+    boost::shared_ptr<YieldCurveConfig> yCConfig = boost::make_shared<YieldCurveConfig>(
+        "EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
+    curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
+
+    vector<string> data{"2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-13 1.0",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14 0.99",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15 0.98",
+                        "2023-10-13 EQUITY_FWD/PRICE/SP5/USD/1Y 1500.00",
+                        "2023-10-13 EQUITY_FWD/PRICE/SP5/USD/20231014 1500.00",
+                        "2023-10-13 EQUITY_DIVIDEND/RATE/SP5/USD/20231015 0.00",
+                        "2023-10-13 EQUITY_DIVIDEND/RATE/SP5/USD/2Y 0.00"};
+    MarketDataLoader loader(data);
+
+    BOOST_CHECK_NO_THROW(YieldCurve yieldCurve(asof, spec, curveConfigs, loader));
+}
+
 // Test ARS-IN-USD failures using the old QuantLib::IterativeBootstrap parameters
 BOOST_DATA_TEST_CASE(testBootstrapARSinUSDFailures, bdata::make(curveConfigFiles), curveConfigFile) {
 

--- a/OREData/test/yieldcurve.cpp
+++ b/OREData/test/yieldcurve.cpp
@@ -263,10 +263,10 @@ BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegment) {
         "Discount", "", quotes)};
 
     boost::shared_ptr<YieldCurveConfig> yCConfig =
-        boost::make_shared<YieldCurveConfig>("EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
+        boost::make_shared<YieldCurveConfig>("EUR-CURVE", "ORE YieldCurve built from EUR-CURVE", "EUR", "", segments);
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
-    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE/2023-10-13 0.77",
+    vector<string> data{"2023-10-12 DISCOUNT/RATE/SEK/STINA-CURVE/2023-10-13 0.77",
                         "2023-10-12 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-13 0.95",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-14 0.95",
                         "2023-10-12 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-12 0.88",
@@ -297,10 +297,10 @@ BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegmentWildcard) {
         boost::make_shared<DirectYieldCurveSegment>("Discount", "", quotes)};
 
     boost::shared_ptr<YieldCurveConfig> yCConfig = boost::make_shared<YieldCurveConfig>(
-        "EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
+        "EUR-CURVE", "ORE YieldCurve built from EUR-CURVE", "EUR", "", segments);
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
-    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE/2023-10-13 0.77",
+    vector<string> data{"2023-10-12 DISCOUNT/RATE/SEK/STINA-CURVE/2023-10-13 0.77",
                         "2023-10-12 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-13 0.95",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-14 0.95",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",

--- a/OREData/test/yieldcurve.cpp
+++ b/OREData/test/yieldcurve.cpp
@@ -267,6 +267,8 @@ BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegment) {
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
     vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE/2023-10-13 0.77",
+                        "2023-10-12 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-13 0.95",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-14 0.95",
                         "2023-10-12 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-12 0.88",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-14 0.99",
@@ -298,7 +300,10 @@ BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegmentWildcard) {
         "EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
-    vector<string> data{"2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",
+    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE/2023-10-13 0.77",
+                        "2023-10-12 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-13 0.95",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-ANOTHER-CURVE/2023-10-14 0.95",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-14 0.99",
                         "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-15 0.98",
                         "2023-10-13 EQUITY_FWD/PRICE/SP5/USD/1Y 1500.00",

--- a/OREData/test/yieldcurve.cpp
+++ b/OREData/test/yieldcurve.cpp
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixings) {
     BOOST_CHECK_NO_THROW(YieldCurve jpyYieldCurve(asof, spec, curveConfigs, loader));
 }
 
-BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYc) {
+BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegment) {
 
     Date asof(13, October, 2023);
     Settings::instance().evaluationDate() = asof;
@@ -256,8 +256,8 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYc) {
     CurveConfigurations curveConfigs;
 
     vector<string> quotes;
-    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14");
-    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15");
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-14");
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-15");
 
     vector<boost::shared_ptr<YieldCurveSegment>> segments{boost::make_shared<DirectYieldCurveSegment>(
         "Discount", "", quotes)};
@@ -266,11 +266,11 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYc) {
         boost::make_shared<YieldCurveConfig>("EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
-    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE_2023-10-12/2023-10-13 0.77",
-                        "2023-10-12 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-12/2023-10-12 0.88",
-                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-13 1.0",
-                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14 0.99",
-                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15 0.98",
+    vector<string> data{"2023-10-12 DISCOUNT/RATE/EUR/STINA-CURVE/2023-10-13 0.77",
+                        "2023-10-12 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-12 0.88",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-14 0.99",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-15 0.98",
                         "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-10-31 1158.8",
                         "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-11-01 1160.9",
                         "2023-10-13 COMMODITY_FWD/PRICE/GOLD/USD/2023-11-02 1163.4"};
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYc) {
     BOOST_CHECK_NO_THROW(YieldCurve yieldCurve(asof, spec, curveConfigs, loader));
 }
 
-BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYcWildChar) {
+BOOST_AUTO_TEST_CASE(testBuildDiscountCurveDirectSegmentWildcard) {
 
     Date asof(13, October, 2023);
     Settings::instance().evaluationDate() = asof;
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYcWildChar) {
     CurveConfigurations curveConfigs;
 
     vector<string> quotes;
-    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/*");
+    quotes.emplace_back("DISCOUNT/RATE/EUR/EUR-CURVE/*");
 
     vector<boost::shared_ptr<YieldCurveSegment>> segments{
         boost::make_shared<DirectYieldCurveSegment>("Discount", "", quotes)};
@@ -298,9 +298,9 @@ BOOST_AUTO_TEST_CASE(testBootstrapAndFixingsDirectYcWildChar) {
         "EUR-CURVE", "ORE YieldCurve built from EUR-CURVE_2023-10-13", "EUR", "", segments);
     curveConfigs.add(CurveSpec::CurveType::Yield, "EUR-CURVE", yCConfig);
 
-    vector<string> data{"2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-13 1.0",
-                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-14 0.99",
-                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE_2023-10-13/2023-10-15 0.98",
+    vector<string> data{"2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-13 1.0",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-14 0.99",
+                        "2023-10-13 DISCOUNT/RATE/EUR/EUR-CURVE/2023-10-15 0.98",
                         "2023-10-13 EQUITY_FWD/PRICE/SP5/USD/1Y 1500.00",
                         "2023-10-13 EQUITY_FWD/PRICE/SP5/USD/20231014 1500.00",
                         "2023-10-13 EQUITY_DIVIDEND/RATE/SP5/USD/20231015 0.00",


### PR DESCRIPTION
It will also improve the performance when reading market data since it will be read once instead
of looping the market data for each quote.
Testing that both using all quotes for segments like before work but now also a convenient usage with wildcard
works for example:
```
<Segments>
  <Direct>
    <Type>Discount</Type>
    <Quotes>
      <Quote>DISCOUNT/RATE/EUR/EUR3M/*</Quote>
    </Quotes>
    <Conventions/>
  </Direct>
</Segments>
```
Updated document with this change.
 
Also corrected mistake in example document that Discount quote does not use day count convention.