### PR TITLE
call enableExtrapolation() before h_.linkTo(p_) in YieldCurve

### DIFF
--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -280,10 +280,10 @@ YieldCurve::YieldCurve(Date asof, YieldCurveSpec curveSpec, const CurveConfigura
             buildBootstrappedCurve();
         }
 
-        h_.linkTo(p_);
         if (extrapolation_) {
-            h_->enableExtrapolation();
+            p_->enableExtrapolation();
         }
+        h_.linkTo(p_);
 
         // populate shared calibration info
 

--- a/OREData/ored/portfolio/fxdigitaloption.cpp
+++ b/OREData/ored/portfolio/fxdigitaloption.cpp
@@ -51,6 +51,7 @@ void FxDigitalOption::build(const boost::shared_ptr<EngineFactory>& engineFactor
     bool flipResults = false;
     if (payoffCurrency_ == "") {
         DLOG("PayoffCurrency defaulting to " << domesticCurrency_ << " for FxDigitalOption " << id());
+        payoffCurrency_ = domesticCurrency_;
     } else if (payoffCurrency_ == foreignCurrency_) {
         // Invert the trade, switch dom and for and flip Put/Call
         strike = 1.0 / strike;


### PR DESCRIPTION
Change enableExtrapolation() to be called before h_.linkTo(p_) so that the correct extrapolation_ value is available in h_'s observers