### PR TITLE
Use CMAKE_MODULE_PATH

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(App CXX)
 
-include("../cmake/commonSettings.cmake")
+include(commonSettings)
 
 get_library_name("OREPlusBase" OREPBASE_LIB_NAME)
 get_library_name("OREAnalytics" OREA_LIB_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,11 @@ option(ORE_USE_ZLIB "Use compression for boost::iostreams" OFF)
 
 include(CTest)
 
-include("cmake/commonSettings.cmake")
+# Path for local cmake modules
+if(NOT "${CMAKE_CURRENT_LIST_DIR}/cmake" IN_LIST CMAKE_MODULE_PATH)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+endif()
+include(commonSettings)
 
 set(USE_GLOBAL_ORE_BUILD ON)
 

--- a/OREAnalytics/CMakeLists.txt
+++ b/OREAnalytics/CMakeLists.txt
@@ -4,8 +4,8 @@ project(OREAnalytics CXX)
 
 enable_testing()
 
-include("../cmake/writeAll.cmake")
-include("../cmake/commonSettings.cmake")
+include(writeAll)
+include(commonSettings)
 
 get_library_name("OREAnalytics" OREA_LIB_NAME)
 get_library_name("OREData" ORED_LIB_NAME)

--- a/OREData/CMakeLists.txt
+++ b/OREData/CMakeLists.txt
@@ -4,8 +4,8 @@ project(OREData CXX)
 
 enable_testing()
 
-include("../cmake/writeAll.cmake")
-include("../cmake/commonSettings.cmake")
+include(writeAll)
+include(commonSettings)
 
 get_library_name("OREData" ORED_LIB_NAME)
 get_library_name("QuantExt" QLE_LIB_NAME)

--- a/QuantExt/CMakeLists.txt
+++ b/QuantExt/CMakeLists.txt
@@ -4,9 +4,9 @@ project(QuantExt CXX)
 
 enable_testing()
 
-include("../cmake/writeAll.cmake")
-include("../cmake/writeTestSuiteMain.cmake")
-include("../cmake/commonSettings.cmake")
+include(writeAll)
+include(writeTestSuiteMain)
+include(commonSettings)
 
 get_library_name("QuantExt" QLE_LIB_NAME)
 set_ql_library_name()


### PR DESCRIPTION
Specifying a search path for CMake modules to be loaded by the include() or find_package() is more robust for cmake three changes. It is intended to be set by the project.