### PR TITLE
Link Boost static or dynamic for Linux

### DIFF
--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -162,9 +162,7 @@ else()
         set(Boost_USE_RELEASE_LIBS      OFF)
     endif()
     # Issue with Boost CMake finder introduced in version 1.70
-    if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
-        set(Boost_NO_BOOST_CMAKE         ON)
-    endif()
+    set(Boost_NO_BOOST_CMAKE         ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -135,9 +135,29 @@ else()
         set(BUILD_SHARED_LIBS ON)
     endif()
 
-    # link against dynamic boost libraries
-    add_definitions(-DBOOST_ALL_DYN_LINK)
-    add_definitions(-DBOOST_TEST_DYN_LINK)
+    # link against static boost libraries
+    if(NOT DEFINED Boost_USE_STATIC_LIBS)
+        if(BUILD_SHARED_LIBS)
+            set(Boost_USE_STATIC_LIBS 0)
+        else()
+            set(Boost_USE_STATIC_LIBS 1)
+        endif()
+    endif()
+
+    # Boost static runtime ON for MSVC
+    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+        if(BUILD_SHARED_LIBS)
+            set(Boost_USE_STATIC_RUNTIME 0)
+        else()
+            set(Boost_USE_STATIC_RUNTIME 1)
+        endif()
+    endif()
+
+    if(NOT Boost_USE_STATIC_LIBS)
+        # link against dynamic boost libraries
+        add_definitions(-DBOOST_ALL_DYN_LINK)
+        add_definitions(-DBOOST_TEST_DYN_LINK)
+    endif()
 
     # avoid a crash in valgrind that sometimes occurs if this flag is not defined
     add_definitions(-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -156,6 +156,7 @@ else()
     # Use Boost Release
     set(Boost_USE_DEBUG_LIBS        OFF)
     set(Boost_USE_RELEASE_LIBS       ON)
+    set(Boost_NO_BOOST_CMAKE         ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -67,30 +67,6 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY
         "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<BOOL:${MSVC_LINK_DYNAMIC_RUNTIME}>:DLL>")
 
-    # link against static boost libraries
-    if(NOT DEFINED Boost_USE_STATIC_LIBS)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS 0)
-        else()
-            set(Boost_USE_STATIC_LIBS 1)
-        endif()
-    endif()
-
-    # Boost static runtime ON for MSVC
-    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
-        if(BUILD_SHARED_LIBS OR(MSVC AND MSVC_LINK_DYNAMIC_RUNTIME))
-            set(Boost_USE_STATIC_RUNTIME 0)
-        else()
-            set(Boost_USE_STATIC_RUNTIME 1)
-        endif()
-    endif()
-
-
-
-    IF(NOT Boost_USE_STATIC_LIBS)
-        add_definitions(-DBOOST_ALL_DYN_LINK)
-        add_definitions(-DBOOST_TEST_DYN_LINK)
-    endif()
     add_compile_options(/external:env:BOOST)
     add_compile_options(/external:W0)
     add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
@@ -135,40 +111,8 @@ else()
         set(BUILD_SHARED_LIBS ON)
     endif()
 
-    # link against static boost libraries
-    if(NOT DEFINED Boost_USE_STATIC_LIBS)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS OFF)
-        else()
-            set(Boost_USE_STATIC_LIBS ON)
-        endif()
-    endif()
-
-    # Boost static runtime
-    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_RUNTIME OFF)
-        else()
-            set(Boost_USE_STATIC_RUNTIME ON)
-        endif()
-    endif()
-
-    # Use Boost Release/Debug
-    if(CMAKE_BUILD_TYPE MATCHES Release)
-        set(Boost_USE_DEBUG_LIBS        OFF)
-        set(Boost_USE_RELEASE_LIBS       ON)
-    elseif(CMAKE_BUILD_TYPE MATCHES Debug)
-        set(Boost_USE_DEBUG_LIBS         ON)
-        set(Boost_USE_RELEASE_LIBS      OFF)
-    endif()
     # Issue with Boost CMake finder introduced in version 1.70
     set(Boost_NO_BOOST_CMAKE         ON)
-
-    if(NOT Boost_USE_STATIC_LIBS)
-        # link against dynamic boost libraries
-        add_definitions(-DBOOST_ALL_DYN_LINK)
-        add_definitions(-DBOOST_TEST_DYN_LINK)
-    endif()
 
     # avoid a crash in valgrind that sometimes occurs if this flag is not defined
     add_definitions(-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
@@ -225,8 +169,43 @@ else()
     # if QuantLib is build separately
     include_directories("${CMAKE_CURRENT_LIST_DIR}/../QuantLib/build")
 
-   
 endif()
+
+# Boost #
+# link against static boost libraries
+if(NOT DEFINED Boost_USE_STATIC_LIBS)
+    if(BUILD_SHARED_LIBS)
+        set(Boost_USE_STATIC_LIBS OFF)
+    else()
+        set(Boost_USE_STATIC_LIBS ON)
+    endif()
+endif()
+
+# Boost static runtime. ON for MSVC
+if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+    if(BUILD_SHARED_LIBS OR(MSVC AND MSVC_LINK_DYNAMIC_RUNTIME))
+        set(Boost_USE_STATIC_RUNTIME OFF)
+    else()
+        set(Boost_USE_STATIC_RUNTIME ON)
+    endif()
+endif()
+
+if(NOT Boost_USE_STATIC_LIBS)
+    # link against dynamic boost libraries
+    add_definitions(-DBOOST_ALL_DYN_LINK)
+    add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
+
+# Use Boost Release/Debug
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(Boost_USE_DEBUG_LIBS        OFF)
+    set(Boost_USE_RELEASE_LIBS       ON)
+elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(Boost_USE_DEBUG_LIBS         ON)
+    set(Boost_USE_RELEASE_LIBS      OFF)
+endif()
+
+# Boost end #
 
 # workaround when building with boost 1.81, see https://github.com/boostorg/phoenix/issues/111
 add_definitions(-DBOOST_PHOENIX_STL_TUPLE_H_)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -144,7 +144,7 @@ else()
         endif()
     endif()
 
-    # Boost static runtime ON for MSVC
+    # Boost static runtime
     if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
         if(BUILD_SHARED_LIBS)
             set(Boost_USE_STATIC_RUNTIME OFF)
@@ -153,7 +153,7 @@ else()
         endif()
     endif()
 
-    # Use Boost Release
+    # Use Boost Release/Debug
     if(CMAKE_BUILD_TYPE MATCHES Release)
         set(Boost_USE_DEBUG_LIBS        OFF)
         set(Boost_USE_RELEASE_LIBS       ON)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -138,20 +138,24 @@ else()
     # link against static boost libraries
     if(NOT DEFINED Boost_USE_STATIC_LIBS)
         if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS 0)
+            set(Boost_USE_STATIC_LIBS OFF)
         else()
-            set(Boost_USE_STATIC_LIBS 1)
+            set(Boost_USE_STATIC_LIBS ON)
         endif()
     endif()
 
     # Boost static runtime ON for MSVC
     if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
         if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_RUNTIME 0)
+            set(Boost_USE_STATIC_RUNTIME OFF)
         else()
-            set(Boost_USE_STATIC_RUNTIME 1)
+            set(Boost_USE_STATIC_RUNTIME ON)
         endif()
     endif()
+
+    # Use Boost Release
+    set(Boost_USE_DEBUG_LIBS        OFF)
+    set(Boost_USE_RELEASE_LIBS       ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -154,9 +154,17 @@ else()
     endif()
 
     # Use Boost Release
-    set(Boost_USE_DEBUG_LIBS        OFF)
-    set(Boost_USE_RELEASE_LIBS       ON)
-    set(Boost_NO_BOOST_CMAKE         ON)
+    if(CMAKE_BUILD_TYPE MATCHES Release)
+        set(Boost_USE_DEBUG_LIBS        OFF)
+        set(Boost_USE_RELEASE_LIBS       ON)
+    elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(Boost_USE_DEBUG_LIBS         ON)
+        set(Boost_USE_RELEASE_LIBS      OFF)
+    endif()
+    # Issue with Boost CMake finder introduced in version 1.70
+    if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
+        set(Boost_NO_BOOST_CMAKE         ON)
+    endif()
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries


### PR DESCRIPTION
The Boost configuration now includes support for Linux, providing the flexibility to choose between optional static or dynamic linking on this platform. Previously, only shared system linking was feasible. In our company's use case, there is a requirement to create a standalone application for Linux, linked statically with Boost.

With the unified configuration of Boost for both Linux and Windows, we can streamline the code into a common space, enhancing code organization and maintainability.