### PR TITLE
Remove loadQuotesFromXML due to missing definition

### DIFF
--- a/OREData/ored/configuration/yieldcurveconfig.hpp
+++ b/OREData/ored/configuration/yieldcurveconfig.hpp
@@ -122,10 +122,6 @@ protected:
     //! Utility to build a quote, optional flag defaults to false
     pair<string, bool> quote(const string& name, bool opt = false) { return make_pair(name, opt); }
 
-    //! Utility method to read quotes from XML
-    void loadQuotesFromXML(XMLNode* node);
-    //! Utility method to write quotes to XML
-
 private:
     // TODO: why type and typeID?
     Type type_;


### PR DESCRIPTION
Hi,
This is only declared, never defined. It seems leftover after some very old refactoring.