### PR TITLE
Make XSD files include all schema dependencies

### DIFF
--- a/xsd/calendaradjustment.xsd
+++ b/xsd/calendaradjustment.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element type="calendaradjustment" name="CalendarAdjustments"/>
 

--- a/xsd/conventions.xsd
+++ b/xsd/conventions.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element type="conventions" name="Conventions"/>
 

--- a/xsd/creditsimulation.xsd
+++ b/xsd/creditsimulation.xsd
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified">
+  <xs:include schemaLocation="ore_types.xsd"/>
+
   <xs:element type="creditsimulation" name="CreditSimulation"/>
   <xs:complexType name="creditsimulation">
     <xs:all>

--- a/xsd/iborfallbackconfig.xsd
+++ b/xsd/iborfallbackconfig.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element name="IborFallbackConfig">
     <xs:complexType>

--- a/xsd/instruments.xsd
+++ b/xsd/instruments.xsd
@@ -2,6 +2,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="ore_types.xsd"/>
+  <xs:include schemaLocation="scriptlibrary.xsd"/>
 
   <xs:group name="oreTradeData">
     <xs:choice>

--- a/xsd/nettingsetdefinitions.xsd
+++ b/xsd/nettingsetdefinitions.xsd
@@ -1,4 +1,6 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
+  <xs:include schemaLocation="instruments.xsd"/>
 
   <xs:element type="nettingsetdefinitions" name="NettingSetDefinitions"/>
 

--- a/xsd/referencedata.xsd
+++ b/xsd/referencedata.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="instruments.xsd"/>
 
   <xs:element name="ReferenceData">
     <xs:complexType>

--- a/xsd/sensitivity.xsd
+++ b/xsd/sensitivity.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element type="sensitivityanalysis" name="SensitivityAnalysis"/>
 

--- a/xsd/simulation.xsd
+++ b/xsd/simulation.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element type="simulation" name="Simulation"/>
 

--- a/xsd/stress.xsd
+++ b/xsd/stress.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="sensitivity.xsd"/>
 
   <xs:element type="stresstesting" name="StressTesting"/>
 

--- a/xsd/todaysmarket.xsd
+++ b/xsd/todaysmarket.xsd
@@ -1,4 +1,5 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="ore_types.xsd"/>
 
   <xs:element type="todaysmarket" name="TodaysMarket"/>
 


### PR DESCRIPTION
Hi!
Our IDE (PyCharm) used when developing our integrations against ORE makes a big fuss about the XSDs not including all of their dependencies. 