### PR TITLE
Allow negative paymentlag

### DIFF
--- a/Docs/UserGuide/tradecomponents/legdatanotionals.tex
+++ b/Docs/UserGuide/tradecomponents/legdatanotionals.tex
@@ -65,7 +65,7 @@ Allowable values: See Table \ref{tab:convention}.
 \item PaymentLag [optional]: The payment lag applies to Fixed legs, Equity legs, and Floating legs with Ibor and OIS indices (but not to BMA/SIFMA indices), as well as CPI legs and Zero Coupon Fixed legs. \\
 PaymentLag is also not supported for CapFloor Floating legs that have Ibor coupons with sub periods (HasSubPeriods = \emph{true}), nor for CapFloor Floating legs with averaged ON coupons (IsAveraged = \emph{true}).
 
-Allowable values: Any valid period, i.e. a non-negative whole number, optionally followed by \emph{D} (days), \emph{W} (weeks), \emph{M} (months),
+Allowable values: Any valid period, i.e. a positive or negative whole number, optionally followed by \emph{D} (days), \emph{W} (weeks), \emph{M} (months),
   \emph{Y} (years). Defaults to \emph{0D} if left blank or omitted. If a whole number is given and no letter, it is assumed that it is a number of  \emph{D} (days).
 
 \item DayCounter: The day count convention of the leg coupons. Note that \lstinline!DayCounter! is mandatory for all leg types except \emph{Equity}.

--- a/Docs/UserGuide/tradedata/fxforward.tex
+++ b/Docs/UserGuide/tradedata/fxforward.tex
@@ -50,7 +50,7 @@ from the \lstinline!Rules! sub-node.
 The \lstinline!Rules! sub-node is shown in Listing \ref{lst:settlement_data_node}, and the meanings and allowable values of its elements follow below.
   \begin{itemize}
 	\item PaymentLag [Optional]: The lag between the value date and the payment date. \\
-	Allowable values: Any valid period, i.e.\ a non-negative whole number, optionally followed by \emph{D} (days), \emph{W} (weeks), \emph{M} (months),
+	Allowable values: Any valid period, i.e.\ a negative or positive whole number, optionally followed by \emph{D} (days), \emph{W} (weeks), \emph{M} (months),
   \emph{Y} (years). For cash settlement and if a FXIndex is specified defaults to the fx convention (field ``SpotDays'') if blank or omitted, otherwise to 0. If a whole number is given and no letter, it is assumed that it is a number of  \emph{D} (days).
 	\item PaymentCalendar [Optional]: The calendar to be used when applying the payment lag. \\
 	Allowable values: See Table \ref{tab:calendar} \lstinline!Calendar!. For cash settlement and if a FXIndex is specified defaults to the fx convention (field ``AdvanceCalendar'') if left blank or omitted, otherwise to NullCalendar (no holidays).

--- a/OREData/ored/portfolio/types.hpp
+++ b/OREData/ored/portfolio/types.hpp
@@ -29,18 +29,18 @@
 namespace ore {
 namespace data {
 
-typedef boost::variant<QuantLib::Period, QuantLib::Natural> PaymentLag;
+typedef boost::variant<QuantLib::Period, QuantLib::Integer> PaymentLag;
 
 struct PaymentLagPeriod : public boost::static_visitor<QuantLib::Period> {
 public:
-    QuantLib::Period operator()(const QuantLib::Natural& n) const { return Period(n, Days); }
+    QuantLib::Period operator()(const QuantLib::Integer& n) const { return Period(n, Days); }
     QuantLib::Period operator()(const QuantLib::Period& p) const { return p; }
 };
 
-struct PaymentLagInteger : public boost::static_visitor<QuantLib::Natural> {
+struct PaymentLagInteger : public boost::static_visitor<QuantLib::Integer> {
 public:
-    QuantLib::Natural operator()(const QuantLib::Natural& n) const { return n; }
-    QuantLib::Natural operator()(const QuantLib::Period& p) const { return static_cast<QuantLib::Natural>(days(p)); }
+    QuantLib::Integer operator()(const QuantLib::Integer& n) const { return n; }
+    QuantLib::Integer operator()(const QuantLib::Period& p) const { return static_cast<QuantLib::Integer>(days(p)); }
 };
 
 } // namespace data

--- a/OREData/ored/utilities/parsers.cpp
+++ b/OREData/ored/utilities/parsers.cpp
@@ -622,10 +622,10 @@ Month parseMonth(const string& s) {
 
 PaymentLag parsePaymentLag(const string& s) {
     Period p;
-    Natural n;
+    Integer n = 0;
     if (tryParse<Period>(s, p, parsePeriod))
         return p;
-    else if (tryParse<Natural>(s, n, parseInteger))
+    else if (tryParse<Integer>(s, n, parseInteger))
         return n;
     else
         return 0;

--- a/QuantExt/qle/cashflows/averageonindexedcoupon.cpp
+++ b/QuantExt/qle/cashflows/averageonindexedcoupon.cpp
@@ -352,7 +352,7 @@ AverageONLeg& AverageONLeg::withPaymentCalendar(const Calendar& calendar) {
     return *this;
 }
 
-AverageONLeg& AverageONLeg::withPaymentLag(Natural lag) {
+AverageONLeg& AverageONLeg::withPaymentLag(Integer lag) {
     paymentLag_ = lag;
     return *this;
 }

--- a/QuantExt/qle/cashflows/averageonindexedcoupon.hpp
+++ b/QuantExt/qle/cashflows/averageonindexedcoupon.hpp
@@ -190,7 +190,7 @@ public:
     AverageONLeg& withTelescopicValueDates(bool telescopicValueDates);
     AverageONLeg& withRateCutoff(Natural rateCutoff);
     AverageONLeg& withPaymentCalendar(const Calendar& calendar);
-    AverageONLeg& withPaymentLag(Natural lag);
+    AverageONLeg& withPaymentLag(Integer lag);
     AverageONLeg& withLookback(const Period& lookback);
     AverageONLeg& withFixingDays(const Size fixingDays);
     AverageONLeg& withCaps(Rate cap);
@@ -215,7 +215,7 @@ private:
     std::vector<Real> notionals_;
     DayCounter paymentDayCounter_;
     BusinessDayConvention paymentAdjustment_;
-    Natural paymentLag_;
+    Integer paymentLag_;
     std::vector<Real> gearings_;
     std::vector<Spread> spreads_;
     bool telescopicValueDates_;

--- a/QuantExt/qle/cashflows/cpicoupon.cpp
+++ b/QuantExt/qle/cashflows/cpicoupon.cpp
@@ -277,7 +277,7 @@ CPILeg& CPILeg::withPaymentCalendar(const Calendar& cal) {
     return *this;
 }
 
-CPILeg& CPILeg::withPaymentLag(Natural lag) {
+CPILeg& CPILeg::withPaymentLag(Integer lag) {
     paymentLag_ = lag;
     return *this;
 }

--- a/QuantExt/qle/cashflows/cpicoupon.hpp
+++ b/QuantExt/qle/cashflows/cpicoupon.hpp
@@ -146,7 +146,7 @@ public:
     CPILeg& withPaymentDayCounter(const DayCounter&);
     CPILeg& withPaymentAdjustment(BusinessDayConvention);
     CPILeg& withPaymentCalendar(const Calendar&);
-    CPILeg& withPaymentLag(Natural lag);
+    CPILeg& withPaymentLag(Integer lag);
     CPILeg& withFixingDays(Natural fixingDays);
     CPILeg& withFixingDays(const std::vector<Natural>& fixingDays);
     CPILeg& withObservationInterpolation(CPI::InterpolationType);
@@ -175,7 +175,7 @@ private:
     DayCounter paymentDayCounter_;
     BusinessDayConvention paymentAdjustment_;
     Calendar paymentCalendar_;
-    Natural paymentLag_;
+    Integer paymentLag_;
     std::vector<Natural> fixingDays_;
     CPI::InterpolationType observationInterpolation_;
     bool subtractInflationNominal_;

--- a/QuantExt/qle/cashflows/equitycoupon.cpp
+++ b/QuantExt/qle/cashflows/equitycoupon.cpp
@@ -203,7 +203,7 @@ EquityLeg& EquityLeg::withPaymentAdjustment(BusinessDayConvention convention) {
     return *this;
 }
 
-EquityLeg& EquityLeg::withPaymentLag(Natural paymentLag) {
+EquityLeg& EquityLeg::withPaymentLag(Integer paymentLag) {
     paymentLag_ = paymentLag;
     return *this;
 }

--- a/QuantExt/qle/cashflows/equitycoupon.hpp
+++ b/QuantExt/qle/cashflows/equitycoupon.hpp
@@ -166,7 +166,7 @@ public:
     EquityLeg& withNotionals(const std::vector<Real>& notionals);
     EquityLeg& withPaymentDayCounter(const DayCounter& dayCounter);
     EquityLeg& withPaymentAdjustment(BusinessDayConvention convention);
-    EquityLeg& withPaymentLag(Natural paymentLag);
+    EquityLeg& withPaymentLag(Integer paymentLag);
     EquityLeg& withPaymentCalendar(const Calendar& calendar);
     EquityLeg& withReturnType(EquityReturnType);
     EquityLeg& withDividendFactor(Real);
@@ -184,7 +184,7 @@ private:
     boost::shared_ptr<FxIndex> fxIndex_;
     std::vector<Real> notionals_;
     DayCounter paymentDayCounter_;
-    Natural paymentLag_;
+    Integer paymentLag_;
     BusinessDayConvention paymentAdjustment_;
     Calendar paymentCalendar_;
     EquityReturnType returnType_;

--- a/QuantExt/qle/cashflows/overnightindexedcoupon.cpp
+++ b/QuantExt/qle/cashflows/overnightindexedcoupon.cpp
@@ -496,7 +496,7 @@ OvernightLeg& OvernightLeg::withPaymentCalendar(const Calendar& cal) {
     return *this;
 }
 
-OvernightLeg& OvernightLeg::withPaymentLag(Natural lag) {
+OvernightLeg& OvernightLeg::withPaymentLag(Integer lag) {
     paymentLag_ = lag;
     return *this;
 }

--- a/QuantExt/qle/cashflows/overnightindexedcoupon.hpp
+++ b/QuantExt/qle/cashflows/overnightindexedcoupon.hpp
@@ -234,7 +234,7 @@ public:
     OvernightLeg& withPaymentDayCounter(const DayCounter&);
     OvernightLeg& withPaymentAdjustment(BusinessDayConvention);
     OvernightLeg& withPaymentCalendar(const Calendar&);
-    OvernightLeg& withPaymentLag(Natural lag);
+    OvernightLeg& withPaymentLag(Integer lag);
     OvernightLeg& withGearings(Real gearing);
     OvernightLeg& withGearings(const std::vector<Real>& gearings);
     OvernightLeg& withSpreads(Spread spread);
@@ -266,7 +266,7 @@ private:
     DayCounter paymentDayCounter_;
     Calendar paymentCalendar_;
     BusinessDayConvention paymentAdjustment_;
-    Natural paymentLag_;
+    Integer paymentLag_;
     std::vector<Real> gearings_;
     std::vector<Spread> spreads_;
     bool telescopicValueDates_;


### PR DESCRIPTION
This pull request incorporates modifications from QuantLib, enabling the handling of negative payment lags, as implemented in [QuantLib PR #1818](https://github.com/lballabio/QuantLib/pull/1818).

It is recommended to merge this pull request after updating ORE QuantLib with the corresponding changes.