### PR TITLE
Bump actions to v4 for Node20

### DIFF
--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -35,7 +35,7 @@ jobs:
             platform: x64
             boost-lib: 64
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get QuantLib
       run: |
         git submodule update --init

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -57,7 +57,7 @@ jobs:
         cmake --build . -j 2 --verbose
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ore-windows-${{ matrix.arch }}
         path: D:\a\Engine\Engine\build\App\ore.exe

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -40,7 +40,7 @@ jobs:
       run: cd build/; pwd; cmake --build . -j $(nproc)
     - name: Save executables as artifacts
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ore-exe-linux
         path: /home/runner/work/Engine/Engine/build/App/ore

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -26,7 +26,7 @@ jobs:
     name: building
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get QuantLib
       run: |
         git submodule update --init

--- a/.github/workflows/macos_ARM64_build.yaml
+++ b/.github/workflows/macos_ARM64_build.yaml
@@ -45,7 +45,7 @@ jobs:
         cmake --install .
     - name: Save executables as artifacts
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ore-macos-arm64
         path: /Users/runner/work/Engine/Engine/build/App/ore

--- a/.github/workflows/macos_ARM64_build.yaml
+++ b/.github/workflows/macos_ARM64_build.yaml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get QuantLib
       run: |
         git submodule update --init


### PR DESCRIPTION
Hi,
This resolves the warning shown in the action run here: https://github.com/OpenSourceRisk/Engine/actions/runs/8184916349