### PR TITLE
Feature/run tests in GitHub actions

### DIFF
--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -53,18 +53,7 @@ jobs:
         mkdir build
         cd build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} -vcvars_ver=14.3 || exit 1
-        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release `
-                         -DQL_BUILD_EXAMPLES=false `
-                         -DQL_BUILD_TEST_SUITE=false `
-                         -DQL_BUILD_BENCHMARK=false `
-                         -DQL_ENABLE_SESSIONS=true `
-                         -DORE_BUILD_DOC=false `
-                         -DORE_BUILD_EXAMPLES=false `
-                         -DORE_BUILD_APP=true `
-                         -DORE_BUILD_TESTS=true `
-                         -DBOOST_INCLUDEDIR=C:\local\boost `
-                         -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 `
-                         -L
+        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=true -DORE_BUILD_DOC=false -DORE_BUILD_EXAMPLES=false -DORE_BUILD_APP=true -DORE_BUILD_TESTS=true -DBOOST_INCLUDEDIR=C:\local\boost -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 -L
     - name: cmake build
       run: |
         cd build

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -45,7 +45,7 @@ jobs:
         (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
         Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\local\boost"
         choco install -y ninja
-    - name: cmake configure
+    - name: cmake configure and build
       env:
         BOOST_ROOT: C:\local\boost
       shell: cmd
@@ -54,9 +54,6 @@ jobs:
         cd build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} -vcvars_ver=14.3 || exit 1
         cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=true -DORE_BUILD_DOC=false -DORE_BUILD_EXAMPLES=false -DORE_BUILD_APP=true -DORE_BUILD_TESTS=true -DBOOST_INCLUDEDIR=C:\local\boost -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 -L
-    - name: cmake build
-      run: |
-        cd build
         cmake --build . -j 2 --verbose
     - name: Debug
       run: |

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -73,7 +73,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ore-windows-${{ matrix.arch }}
-        path: D:\a\Engine\Engine\build\App\ore.exe
+        path: ${{ github.workspace }}\build\App\ore.exe
 
   tests:
     name: testing
@@ -85,7 +85,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-suites
-          path: ${{ github.workspace }}/test-suites
+          path: ${{ github.workspace }}\test-suites
       - name: run QuantExt tests
         run: |
           .\test-suites\QuantExt\test\quantext-test-suite

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -54,7 +54,7 @@ jobs:
         cd build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} -vcvars_ver=14.3 || exit 1
         cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=true -DORE_BUILD_DOC=false -DORE_BUILD_EXAMPLES=false -DORE_BUILD_APP=true -DORE_BUILD_TESTS=true -DBOOST_INCLUDEDIR=C:\local\boost -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 -L
-        cmake --build . -j 2 --verbose
+        cmake --build . -j 4 --verbose
     - name: Debug
       run: |
         pwd

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Debug
       run: |
         pwd
-        ls -ltrha ./build
+        ls ./build
         echo ${{ github.workspace }}
     - name: Save tests artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -45,7 +45,7 @@ jobs:
         (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
         Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\local\boost"
         choco install -y ninja
-    - name: cmake configure and build
+    - name: cmake configure
       env:
         BOOST_ROOT: C:\local\boost
       shell: cmd
@@ -65,6 +65,9 @@ jobs:
                          -DBOOST_INCLUDEDIR=C:\local\boost \
                          -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 \
                          -L
+    - name: cmake build
+      run: |
+        cd build
         cmake --build . -j 2 --verbose
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -62,6 +62,7 @@ jobs:
         echo ${{ github.workspace }}
     - name: Save tests artifacts
       uses: actions/upload-artifact@v4
+      if: ${{ matrix.arch == 'AMD64' }}
       with:
         name: test-suites
         path: |

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -53,7 +53,18 @@ jobs:
         mkdir build
         cd build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} -vcvars_ver=14.3 || exit 1
-        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=true -DORE_BUILD_DOC=false -DBOOST_INCLUDEDIR=C:\local\boost -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 -L
+        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
+                         -DQL_BUILD_EXAMPLES=false \
+                         -DQL_BUILD_TEST_SUITE=false \
+                         -DQL_BUILD_BENCHMARK=false \
+                         -DQL_ENABLE_SESSIONS=true \
+                         -DORE_BUILD_DOC=false \
+                         -DORE_BUILD_EXAMPLES=false \
+                         -DORE_BUILD_APP=true \
+                         -DORE_BUILD_TESTS=true \
+                         -DBOOST_INCLUDEDIR=C:\local\boost \
+                         -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 \
+                         -L
         cmake --build . -j 2 --verbose
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -74,3 +74,24 @@ jobs:
       with:
         name: ore-windows-${{ matrix.arch }}
         path: D:\a\Engine\Engine\build\App\ore.exe
+
+  tests:
+    name: testing
+    runs-on: windows-2022
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-suites
+          path: ${{ github.workspace }}/test-suites
+      - name: run QuantExt tests
+        run: |
+          .\test-suites\QuantExt\test\quantext-test-suite
+      - name: run OREData tests
+        run: |
+          .\test-suites\OREData\test\ored-test-suite -- --base_data_path=.\OREData\test
+      - name: run OREAnalytics tests
+        run: |
+          .\test-suites\OREAnalytics\test\orea-test-suite

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -65,9 +65,9 @@ jobs:
       with:
         name: test-suites
         path: |
-          ${{ github.workspace }}\build\OREData\test\ored-test-suite
-          ${{ github.workspace }}\build\OREAnalytics\test\orea-test-suite
-          ${{ github.workspace }}\build\QuantExt\test\quantext-test-suite
+          ${{ github.workspace }}\build\OREData\test\ored-test-suite.exe
+          ${{ github.workspace }}\build\OREAnalytics\test\orea-test-suite.exe
+          ${{ github.workspace }}\build\QuantExt\test\quantext-test-suite.exe
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3
@@ -88,10 +88,10 @@ jobs:
           path: ${{ github.workspace }}\test-suites
       - name: run QuantExt tests
         run: |
-          .\test-suites\QuantExt\test\quantext-test-suite
+          .\test-suites\QuantExt\test\quantext-test-suite.exe
       - name: run OREData tests
         run: |
-          .\test-suites\OREData\test\ored-test-suite -- --base_data_path=.\OREData\test
+          .\test-suites\OREData\test\ored-test-suite.exe -- --base_data_path=.\OREData\test
       - name: run OREAnalytics tests
         run: |
-          .\test-suites\OREAnalytics\test\orea-test-suite
+          .\test-suites\OREAnalytics\test\orea-test-suite.exe

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -58,16 +58,16 @@ jobs:
     - name: Debug
       run: |
         pwd
-        ls ./build
+        ls .\build\OREData\test
         echo ${{ github.workspace }}
     - name: Save tests artifacts
       uses: actions/upload-artifact@v4
       with:
         name: test-suites
         path: |
-          ${{ github.workspace }}/build/OREData/test/ored-test-suite
-          ${{ github.workspace }}/build/OREAnalytics/test/orea-test-suite
-          ${{ github.workspace }}/build/QuantExt/test/quantext-test-suite
+          ${{ github.workspace }}\build\OREData\test\ored-test-suite
+          ${{ github.workspace }}\build\OREAnalytics\test\orea-test-suite
+          ${{ github.workspace }}\build\QuantExt\test\quantext-test-suite
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -53,22 +53,35 @@ jobs:
         mkdir build
         cd build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} -vcvars_ver=14.3 || exit 1
-        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
-                         -DQL_BUILD_EXAMPLES=false \
-                         -DQL_BUILD_TEST_SUITE=false \
-                         -DQL_BUILD_BENCHMARK=false \
-                         -DQL_ENABLE_SESSIONS=true \
-                         -DORE_BUILD_DOC=false \
-                         -DORE_BUILD_EXAMPLES=false \
-                         -DORE_BUILD_APP=true \
-                         -DORE_BUILD_TESTS=true \
-                         -DBOOST_INCLUDEDIR=C:\local\boost \
-                         -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 \
+        cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release `
+                         -DQL_BUILD_EXAMPLES=false `
+                         -DQL_BUILD_TEST_SUITE=false `
+                         -DQL_BUILD_BENCHMARK=false `
+                         -DQL_ENABLE_SESSIONS=true `
+                         -DORE_BUILD_DOC=false `
+                         -DORE_BUILD_EXAMPLES=false `
+                         -DORE_BUILD_APP=true `
+                         -DORE_BUILD_TESTS=true `
+                         -DBOOST_INCLUDEDIR=C:\local\boost `
+                         -DBOOST_LIBRARYDIR=C:\local\boost\lib64-msvc-14.3 `
                          -L
     - name: cmake build
       run: |
         cd build
         cmake --build . -j 2 --verbose
+    - name: Debug
+      run: |
+        pwd
+        ls -ltrha ./build
+        echo ${{ github.workspace }}
+    - name: Save tests artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-suites
+        path: |
+          ${{ github.workspace }}/build/OREData/test/ored-test-suite
+          ${{ github.workspace }}/build/OREAnalytics/test/orea-test-suite
+          ${{ github.workspace }}/build/QuantExt/test/quantext-test-suite
     - name: Save executables as artifacts
       #if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -48,7 +48,6 @@ jobs:
                             -DORE_BUILD_EXAMPLES=false \
                             -DORE_BUILD_APP=true \
                             -DORE_BUILD_TESTS=true \
-                            -DBUILD_SHARED_LIBS=false \
                             -L
     - name: cmake build
       run: |

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: build
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ored-test-suite
           path: ${{ github.workspace }}/build/OREData/test/ored-test-suite

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -60,7 +60,7 @@ jobs:
     - name: Save tests artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ored-test-suite
+        name: test-suites
         path: |
           ${{ github.workspace }}/build/OREData/test/ored-test-suite
           ${{ github.workspace }}/build/OREAnalytics/test/orea-test-suite
@@ -78,14 +78,15 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     steps:
+      - uses: actions/checkout@v4
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ored-test-suite
-          path: ${{ github.workspace }}/build/OREData/test/ored-test-suite
+          name: test-suites
+          path: ${{ github.workspace }}/test-suites
       - name: Debug
         run: |
-          ls -ltrha ${{ github.workspace }}/build/OREData/test/ored-test-suite
+          ls -ltrha ${{ github.workspace }}/test-suites
       - name: run OREData tests
         run: |
-          ${{ github.workspace }}/build/OREData/test/ored-test-suite -- --base_data_path=OREData/test
+          ${{ github.workspace }}/test-suites/ored-test-suite -- --base_data_path=Engine/OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -54,7 +54,9 @@ jobs:
                             -DBUILD_SHARED_LIBS=false \
                             -L
     - name: cmake build
-      run: cd build/; pwd; cmake --build . -j $(nproc)
+      run: |
+        cd build
+        cmake --build . -j $(nproc)
     - name: Debug
       run: |
         ls ${{ github.workspace }}

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -61,7 +61,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ored-test-suite
-        path: ${{ github.workspace }}/build/OREData/test/ored-test-suite
+        path: |
+          ${{ github.workspace }}/build/OREData/test/ored-test-suite
+          ${{ github.workspace }}/build/OREAnalytics/test/orea-test-suite
+          ${{ github.workspace }}/build/QuantExt/test/quantext-test-suite
     - name: Save executables as artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -95,4 +95,5 @@ jobs:
         run: |
           ls -ltrha
           pwd
+          ls -ltrha ./Engine/OREData/test
           ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=./Engine/OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -51,6 +51,7 @@ jobs:
                             -DORE_BUILD_EXAMPLES=false \
                             -DORE_BUILD_APP=true \
                             -DORE_BUILD_TESTS=true \
+                            -DBUILD_SHARED_LIBS=false \
                             -L
     - name: cmake build
       run: cd build/; pwd; cmake --build . -j $(nproc)

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -54,6 +54,11 @@ jobs:
                             -L
     - name: cmake build
       run: cd build/; pwd; cmake --build . -j $(nproc)
+    - name: Debug
+      run: |
+        ls ${GITHUB_WORKSPACE}/build
+        ls ${GITHUB_WORKSPACE}/build/OREData
+        ls ${GITHUB_WORKSPACE}/build/OREData/test
     - name: Save tests artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+    - name: Debug
+        run: |
+        echo ${GITHUB_WORKSPACE}
     - name: get QuantLib
       run: |
         git submodule update --init

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -61,7 +61,7 @@ jobs:
       run: |
         ls ${{ github.workspace }}
     - name: Save tests artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-suites
         path: |
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-suites
           path: ${{ github.workspace }}/test-suites

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -89,6 +89,7 @@ jobs:
           ls -ltrha ${{ github.workspace }}/test-suites
           ls -ltrha ${{ github.workspace }}/test-suites/OREData
           ls -ltrha ${{ github.workspace }}/test-suites/OREData/test
+          chmod +x ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite
       - name: run OREData tests
         run: |
           ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=Engine/OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Debug
-        run: |
+      run: |
         echo ${GITHUB_WORKSPACE}
     - name: get QuantLib
       run: |

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -86,16 +86,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-suites
-          path: ${{ github.workspace }}/test-suites
+          path: ${{ github.workspace }}/test-suites         
       - name: Debug
         run: |
-          ls -ltrha ${{ github.workspace }}/test-suites
-          ls -ltrha ${{ github.workspace }}/test-suites/OREData
-          ls -ltrha ${{ github.workspace }}/test-suites/OREData/test
-          chmod +x ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite
+          pwd
+          ls -ltrha ./OREData/test
+          ls -ltrha ./OREAnalytics/test
+          ls -ltrha ./QuantExt/test
       - name: run OREData tests
         run: |
-          ls -ltrha
           pwd
-          ls -ltrha ./Engine/OREData/test
-          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=./Engine/OREData/test
+          ls -ltrha ./OREData/test
+          chmod +x ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite
+          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=./OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -83,6 +83,9 @@ jobs:
         with:
           name: ored-test-suite
           path: ${{ github.workspace }}/build/OREData/test/ored-test-suite
+      - name: Debug
+        run: |
+          ls -ltrha ${{ github.workspace }}/build/OREData/test/ored-test-suite
       - name: run OREData tests
         run: |
           ${{ github.workspace }}/build/OREData/test/ored-test-suite -- --base_data_path=OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -87,6 +87,8 @@ jobs:
       - name: Debug
         run: |
           ls -ltrha ${{ github.workspace }}/test-suites
+          ls -ltrha ${{ github.workspace }}/test-suites/OREData
+          ls -ltrha ${{ github.workspace }}/test-suites/OREData/test
       - name: run OREData tests
         run: |
-          ${{ github.workspace }}/test-suites/ored-test-suite -- --base_data_path=Engine/OREData/test
+          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=Engine/OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -38,7 +38,20 @@ jobs:
         sudo apt update
         sudo apt install -y libboost-all-dev libboost-test-dev ninja-build
     - name: cmake configure
-      run : mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=false -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=true -DORE_BUILD_DOC=false -G "Ninja" ..
+      run : |
+        mkdir build
+        cd build
+        cmake .. -G "Ninja" -DCMAKE_BUILD_TYPE=Release \
+                            -DBUILD_SHARED_LIBS=false \
+                            -DQL_BUILD_EXAMPLES=false \
+                            -DQL_BUILD_TEST_SUITE=false \
+                            -DQL_BUILD_BENCHMARK=false \
+                            -DQL_ENABLE_SESSIONS=true \
+                            -DORE_BUILD_DOC=false \
+                            -DORE_BUILD_EXAMPLES=false \
+                            -DORE_BUILD_APP=true \
+                            -DORE_BUILD_TESTS=true \
+                            -L
     - name: cmake build
       run: cd build/; pwd; cmake --build . -j $(nproc)
     - name: Save executables as artifacts
@@ -46,4 +59,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ore-exe-linux
-        path: /home/runner/work/Engine/Engine/build/App/ore
+        path: ${GITHUB_WORKSPACE}/build/App/ore

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -81,7 +81,15 @@ jobs:
         with:
           name: test-suites
           path: ${{ github.workspace }}/test-suites
+      - name: run QuantExt tests
+        run: |
+          chmod +x ./test-suites/QuantExt/test/quantext-test-suite
+          ./test-suites/QuantExt/test/quantext-test-suite
       - name: run OREData tests
         run: |
           chmod +x ./test-suites/OREData/test/ored-test-suite
           ./test-suites/OREData/test/ored-test-suite -- --base_data_path=./OREData/test
+      - name: run OREAnalytics tests
+        run: |
+          chmod +x ./test-suites/OREAnalytics/test/orea-test-suite
+          ./test-suites/OREAnalytics/test/orea-test-suite

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -54,9 +54,6 @@ jobs:
       run: |
         cd build
         cmake --build . -j $(nproc)
-    - name: Debug
-      run: |
-        ls ${{ github.workspace }}
     - name: Save tests artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - name: Debug
-      run: |
-        echo ${GITHUB_WORKSPACE}
     - name: get QuantLib
       run: |
         git submodule update --init
@@ -86,16 +83,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-suites
-          path: ${{ github.workspace }}/test-suites         
-      - name: Debug
-        run: |
-          pwd
-          ls -ltrha ./OREData/test
-          ls -ltrha ./OREAnalytics/test
-          ls -ltrha ./QuantExt/test
+          path: ${{ github.workspace }}/test-suites
       - name: run OREData tests
         run: |
-          pwd
-          ls -ltrha ./OREData/test
-          chmod +x ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite
-          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=./OREData/test
+          chmod +x ./test-suites/OREData/test/ored-test-suite
+          ./test-suites/OREData/test/ored-test-suite -- --base_data_path=./OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -56,20 +56,18 @@ jobs:
       run: cd build/; pwd; cmake --build . -j $(nproc)
     - name: Debug
       run: |
-        ls ${GITHUB_WORKSPACE}/build
-        ls ${GITHUB_WORKSPACE}/build/OREData
-        ls ${GITHUB_WORKSPACE}/build/OREData/test
+        ls ${{ github.workspace }}
     - name: Save tests artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ored-test-suite
-        path: ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite
+        path: ${{ github.workspace }}/build/OREData/test/ored-test-suite
     - name: Save executables as artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3
       with:
         name: ore-exe-linux
-        path: ${GITHUB_WORKSPACE}/build/App/ore
+        path: ${{ github.workspace }}/build/App/ore
 
 # Run tests
   tests:
@@ -81,7 +79,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ored-test-suite
-          path: ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite
+          path: ${{ github.workspace }}/build/OREData/test/ored-test-suite
       - name: run OREData tests
         run: |
-          ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite -- --base_data_path=OREData/test
+          ${{ github.workspace }}/build/OREData/test/ored-test-suite -- --base_data_path=OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -93,4 +93,6 @@ jobs:
           chmod +x ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite
       - name: run OREData tests
         run: |
-          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=Engine/OREData/test
+          ls -ltrha
+          pwd
+          ${{ github.workspace }}/test-suites/OREData/test/ored-test-suite -- --base_data_path=./Engine/OREData/test

--- a/.github/workflows/linux_build.yaml
+++ b/.github/workflows/linux_build.yaml
@@ -54,9 +54,29 @@ jobs:
                             -L
     - name: cmake build
       run: cd build/; pwd; cmake --build . -j $(nproc)
+    - name: Save tests artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ored-test-suite
+        path: ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite
     - name: Save executables as artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3
       with:
         name: ore-exe-linux
         path: ${GITHUB_WORKSPACE}/build/App/ore
+
+# Run tests
+  tests:
+    name: testing
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ored-test-suite
+          path: ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite
+      - name: run OREData tests
+        run: |
+          ${GITHUB_WORKSPACE}/build/OREData/test/ored-test-suite -- --base_data_path=OREData/test

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -140,20 +140,24 @@ else()
     # link against static boost libraries
     if(NOT DEFINED Boost_USE_STATIC_LIBS)
         if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS 0)
+            set(Boost_USE_STATIC_LIBS OFF)
         else()
-            set(Boost_USE_STATIC_LIBS 1)
+            set(Boost_USE_STATIC_LIBS ON)
         endif()
     endif()
 
     # Boost static runtime ON for MSVC
     if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
         if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_RUNTIME 0)
+            set(Boost_USE_STATIC_RUNTIME OFF)
         else()
-            set(Boost_USE_STATIC_RUNTIME 1)
+            set(Boost_USE_STATIC_RUNTIME ON)
         endif()
     endif()
+
+    # Use Boost Release
+    set(Boost_USE_DEBUG_LIBS        OFF)
+    set(Boost_USE_RELEASE_LIBS       ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -164,9 +164,7 @@ else()
         set(Boost_USE_RELEASE_LIBS      OFF)
     endif()
     # Issue with Boost CMake finder introduced in version 1.70
-    if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
-        set(Boost_NO_BOOST_CMAKE         ON)
-    endif()
+    set(Boost_NO_BOOST_CMAKE         ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -137,9 +137,29 @@ else()
         set(BUILD_SHARED_LIBS ON)
     endif()
 
-    # link against dynamic boost libraries
-    add_definitions(-DBOOST_ALL_DYN_LINK)
-    add_definitions(-DBOOST_TEST_DYN_LINK)
+    # link against static boost libraries
+    if(NOT DEFINED Boost_USE_STATIC_LIBS)
+        if(BUILD_SHARED_LIBS)
+            set(Boost_USE_STATIC_LIBS 0)
+        else()
+            set(Boost_USE_STATIC_LIBS 1)
+        endif()
+    endif()
+
+    # Boost static runtime ON for MSVC
+    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+        if(BUILD_SHARED_LIBS)
+            set(Boost_USE_STATIC_RUNTIME 0)
+        else()
+            set(Boost_USE_STATIC_RUNTIME 1)
+        endif()
+    endif()
+
+    if(NOT Boost_USE_STATIC_LIBS)
+        # link against dynamic boost libraries
+        add_definitions(-DBOOST_ALL_DYN_LINK)
+        add_definitions(-DBOOST_TEST_DYN_LINK)
+    endif()
 
     # avoid a crash in valgrind that sometimes occurs if this flag is not defined
     add_definitions(-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -69,30 +69,6 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY
         "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<BOOL:${MSVC_LINK_DYNAMIC_RUNTIME}>:DLL>")
 
-    # link against static boost libraries
-    if(NOT DEFINED Boost_USE_STATIC_LIBS)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS 0)
-        else()
-            set(Boost_USE_STATIC_LIBS 1)
-        endif()
-    endif()
-
-    # Boost static runtime ON for MSVC
-    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
-        if(BUILD_SHARED_LIBS OR(MSVC AND MSVC_LINK_DYNAMIC_RUNTIME))
-            set(Boost_USE_STATIC_RUNTIME 0)
-        else()
-            set(Boost_USE_STATIC_RUNTIME 1)
-        endif()
-    endif()
-
-
-
-    IF(NOT Boost_USE_STATIC_LIBS)
-        add_definitions(-DBOOST_ALL_DYN_LINK)
-        add_definitions(-DBOOST_TEST_DYN_LINK)
-    endif()
     add_compile_options(/external:env:BOOST)
     add_compile_options(/external:W0)
     add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
@@ -137,40 +113,8 @@ else()
         set(BUILD_SHARED_LIBS ON)
     endif()
 
-    # link against static boost libraries
-    if(NOT DEFINED Boost_USE_STATIC_LIBS)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_LIBS OFF)
-        else()
-            set(Boost_USE_STATIC_LIBS ON)
-        endif()
-    endif()
-
-    # Boost static runtime
-    if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
-        if(BUILD_SHARED_LIBS)
-            set(Boost_USE_STATIC_RUNTIME OFF)
-        else()
-            set(Boost_USE_STATIC_RUNTIME ON)
-        endif()
-    endif()
-
-    # Use Boost Release/Debug
-    if(CMAKE_BUILD_TYPE MATCHES Release)
-        set(Boost_USE_DEBUG_LIBS        OFF)
-        set(Boost_USE_RELEASE_LIBS       ON)
-    elseif(CMAKE_BUILD_TYPE MATCHES Debug)
-        set(Boost_USE_DEBUG_LIBS         ON)
-        set(Boost_USE_RELEASE_LIBS      OFF)
-    endif()
     # Issue with Boost CMake finder introduced in version 1.70
     set(Boost_NO_BOOST_CMAKE         ON)
-
-    if(NOT Boost_USE_STATIC_LIBS)
-        # link against dynamic boost libraries
-        add_definitions(-DBOOST_ALL_DYN_LINK)
-        add_definitions(-DBOOST_TEST_DYN_LINK)
-    endif()
 
     # avoid a crash in valgrind that sometimes occurs if this flag is not defined
     add_definitions(-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
@@ -227,8 +171,43 @@ else()
     # if QuantLib is build separately
     include_directories("${CMAKE_CURRENT_LIST_DIR}/../QuantLib/build")
 
-   
 endif()
+
+# Boost #
+# link against static boost libraries
+if(NOT DEFINED Boost_USE_STATIC_LIBS)
+    if(BUILD_SHARED_LIBS)
+        set(Boost_USE_STATIC_LIBS OFF)
+    else()
+        set(Boost_USE_STATIC_LIBS ON)
+    endif()
+endif()
+
+# Boost static runtime. ON for MSVC
+if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
+    if(BUILD_SHARED_LIBS OR(MSVC AND MSVC_LINK_DYNAMIC_RUNTIME))
+        set(Boost_USE_STATIC_RUNTIME OFF)
+    else()
+        set(Boost_USE_STATIC_RUNTIME ON)
+    endif()
+endif()
+
+if(NOT Boost_USE_STATIC_LIBS)
+    # link against dynamic boost libraries
+    add_definitions(-DBOOST_ALL_DYN_LINK)
+    add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
+
+# Use Boost Release/Debug
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(Boost_USE_DEBUG_LIBS        OFF)
+    set(Boost_USE_RELEASE_LIBS       ON)
+elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(Boost_USE_DEBUG_LIBS         ON)
+    set(Boost_USE_RELEASE_LIBS      OFF)
+endif()
+
+# Boost end #
 
 # workaround when building with boost 1.81, see https://github.com/boostorg/phoenix/issues/111
 add_definitions(-DBOOST_PHOENIX_STL_TUPLE_H_)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -146,7 +146,7 @@ else()
         endif()
     endif()
 
-    # Boost static runtime ON for MSVC
+    # Boost static runtime
     if(NOT DEFINED Boost_USE_STATIC_RUNTIME)
         if(BUILD_SHARED_LIBS)
             set(Boost_USE_STATIC_RUNTIME OFF)
@@ -155,7 +155,7 @@ else()
         endif()
     endif()
 
-    # Use Boost Release
+    # Use Boost Release/Debug
     if(CMAKE_BUILD_TYPE MATCHES Release)
         set(Boost_USE_DEBUG_LIBS        OFF)
         set(Boost_USE_RELEASE_LIBS       ON)

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -158,6 +158,7 @@ else()
     # Use Boost Release
     set(Boost_USE_DEBUG_LIBS        OFF)
     set(Boost_USE_RELEASE_LIBS       ON)
+    set(Boost_NO_BOOST_CMAKE         ON)
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries

--- a/cmake/commonSettings.cmake
+++ b/cmake/commonSettings.cmake
@@ -156,9 +156,17 @@ else()
     endif()
 
     # Use Boost Release
-    set(Boost_USE_DEBUG_LIBS        OFF)
-    set(Boost_USE_RELEASE_LIBS       ON)
-    set(Boost_NO_BOOST_CMAKE         ON)
+    if(CMAKE_BUILD_TYPE MATCHES Release)
+        set(Boost_USE_DEBUG_LIBS        OFF)
+        set(Boost_USE_RELEASE_LIBS       ON)
+    elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(Boost_USE_DEBUG_LIBS         ON)
+        set(Boost_USE_RELEASE_LIBS      OFF)
+    endif()
+    # Issue with Boost CMake finder introduced in version 1.70
+    if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
+        set(Boost_NO_BOOST_CMAKE         ON)
+    endif()
 
     if(NOT Boost_USE_STATIC_LIBS)
         # link against dynamic boost libraries


### PR DESCRIPTION
This PR enhances the GitHub Action workflows for Linux and Windows by incorporating tests for QuantExt, OREData, and OREAnalytics. To enable the execution of Boost unit tests statically on Linux, I have selected and integrated the necessary commits from [PR #209](https://github.com/OpenSourceRisk/Engine/pull/209). As such, it is advisable to merge this PR after the completion of PR #209.