### PR TITLE
Add delta switch tenor

### DIFF
--- a/Docs/UserGuide/conventions.tex
+++ b/Docs/UserGuide/conventions.tex
@@ -837,6 +837,7 @@ structure of this node is shown in Listing \ref{lst:fx_option_conventions}.
   <LongTermDeltaType>Fwd</LongTermDeltaType>
   <RiskReversalInFavorOf>Call</RiskReversalInFavorOf>
   <ButterflyStyle>Broker</ButterflyStyle>
+  <DeltaSwitchTenor>2Y</DeltaSwitchTenor>
 </FxOption>
 \end{minted} 
 \caption{FX option conventions} 
@@ -857,9 +858,12 @@ AtmDeltaNeutral, AtmVegaMax, AtmGammaMax, AtmPutCall50}).
 \item LongTermAtmType [Mandatory if and only if SwitchTenor is given]: ATM type to use for options with tenor > switch
   point, if SwitchTenor is given
 \item LongTermDeltaType [Mandatory if and only if SwitchTenor is given]: Delta type to use for options with tenor >
-  switch point, if SwitchTenor is given
+  switch point, if SwitchTenor is given. DeltaSwitchTenor will be used instead of SwitchTenor if given.
 \item RiskReversalInFavorOf [Optional]: Call (default), Put. Only relevant for BF, RR market data input.
 \item ButterflyStyle [Optional]: Broker (default), Smile. Only relevant for BF, RR market data input.
+\item DeltaSwitchTenor [Optional]: If given, different Delta conventions will be used if the option tenor is greater
+  or equal the delta switch tenor (``long term'' delta type). If not provided SwitchTenor will be used instead for backward 
+  compatibility.
 \end{itemize} 
 
 %- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/OREData/ored/configuration/conventions.cpp
+++ b/OREData/ored/configuration/conventions.cpp
@@ -2223,13 +2223,13 @@ bool CommodityFutureConvention::validateBdc(const ProhibitedExpiry& pe) const {
     return true;
 }
 
-FxOptionConvention::FxOptionConvention(const string& id, const string& atmType, const string& deltaType,
+FxOptionConvention::FxOptionConvention(const string& id, const string& fxConventionID, const string& atmType, const string& deltaType,
                                        const string& switchTenor, const string& longTermAtmType,
                                        const string& longTermDeltaType, const string& riskReversalInFavorOf,
-                                       const string& butterflyStyle, const string& fxConventionID)
+                                       const string& butterflyStyle, const string& deltaSwitchTenor)
     : Convention(id, Type::FxOption), fxConventionID_(fxConventionID), strAtmType_(atmType), strDeltaType_(deltaType),
       strSwitchTenor_(switchTenor), strLongTermAtmType_(longTermAtmType), strLongTermDeltaType_(longTermDeltaType),
-      strRiskReversalInFavorOf_(riskReversalInFavorOf), strButterflyStyle_(butterflyStyle) {
+      strRiskReversalInFavorOf_(riskReversalInFavorOf), strButterflyStyle_(butterflyStyle), strDeltaSwitchTenor_(deltaSwitchTenor) {
     build();
 }
 
@@ -2257,6 +2257,11 @@ void FxOptionConvention::build() {
     } else {
         QL_FAIL("invalid butterfly style '" << strButterflyStyle_ << "', expected Broker or Smile");
     }
+    if (!strDeltaSwitchTenor_.empty()) {
+        deltaSwitchTenor_ = parsePeriod(strDeltaSwitchTenor_);
+    } else {
+        deltaSwitchTenor_ = 0 * Days;
+    }
 }
 
 void FxOptionConvention::fromXML(XMLNode* node) {
@@ -2274,6 +2279,7 @@ void FxOptionConvention::fromXML(XMLNode* node) {
     strLongTermDeltaType_ = XMLUtils::getChildValue(node, "LongTermDeltaType", false);
     strRiskReversalInFavorOf_ = XMLUtils::getChildValue(node, "RiskReversalInFavorOf", false);
     strButterflyStyle_ = XMLUtils::getChildValue(node, "ButterflyStyle", false);
+    strDeltaSwitchTenor_ = XMLUtils::getChildValue(node, "DeltaSwitchTenor", false);
     build();
 }
 
@@ -2289,6 +2295,7 @@ XMLNode* FxOptionConvention::toXML(XMLDocument& doc) {
     XMLUtils::addChild(doc, node, "LongTermDeltaType", strLongTermDeltaType_);
     XMLUtils::addChild(doc, node, "RiskReversalInFavorOf", strRiskReversalInFavorOf_);
     XMLUtils::addChild(doc, node, "ButterflyStyle", strButterflyStyle_);
+    XMLUtils::addChild(doc, node, "DeltaSwitchTenor", strDeltaSwitchTenor_);
     return node;
 }
 

--- a/OREData/ored/configuration/conventions.hpp
+++ b/OREData/ored/configuration/conventions.hpp
@@ -1703,7 +1703,7 @@ public:
     FxOptionConvention(const string& id, const string& fxConventionId, const string& atmType, const string& deltaType,
                        const string& switchTenor = "", const string& longTermAtmType = "",
                        const string& longTermDeltaType = "", const string& riskReversalInFavorOf = "Call",
-                       const string& butterflyStyle = "Broker");
+                       const string& butterflyStyle = "Broker", const string& deltaSwitchTenor = "");
     //@}
 
     //! \name Inspectors
@@ -1716,6 +1716,7 @@ public:
     const DeltaVolQuote::DeltaType& longTermDeltaType() const { return longTermDeltaType_; }
     const QuantLib::Option::Type& riskReversalInFavorOf() const { return riskReversalInFavorOf_; }
     const bool butterflyIsBrokerStyle() const { return butterflyIsBrokerStyle_; }
+    const Period& deltaSwitchTenor() const { return deltaSwitchTenor_; }
     //@}
 
     //! \name Serialisation
@@ -1731,6 +1732,7 @@ private:
     Period switchTenor_;
     QuantLib::Option::Type riskReversalInFavorOf_;
     bool butterflyIsBrokerStyle_;
+    Period deltaSwitchTenor_;
 
     // Strings to store the inputs
     string strAtmType_;
@@ -1740,6 +1742,7 @@ private:
     string strLongTermDeltaType_;
     string strRiskReversalInFavorOf_;
     string strButterflyStyle_;
+    string strDeltaSwitchTenor_;
 };
 
 /*! Container for storing zero inflation index conventions

--- a/OREData/ored/marketdata/fxvolcurve.cpp
+++ b/OREData/ored/marketdata/fxvolcurve.cpp
@@ -227,7 +227,7 @@ void FXVolCurve::buildSmileDeltaCurve(Date asof, FXVolatilityCurveSpec spec, con
                    [](const std::pair<Real, string>& x) { return x.first; });
     vol_ = boost::make_shared<QuantExt::BlackVolatilitySurfaceDelta>(
         asof, dates, putDeltasNum, callDeltasNum, hasATM, blackVolMatrix, dc, cal, fxSpot_, domYts_, forYts_,
-        deltaType_, atmType_, boost::none, switchTenor_, longTermDeltaType_, longTermAtmType_, boost::none, interp);
+        deltaType_, atmType_, boost::none, switchTenor_, longTermDeltaType_, longTermAtmType_, boost::none, interp, true, deltaSwitchTenor_);
 
     vol_->enableExtrapolation();
 }
@@ -865,6 +865,7 @@ void FXVolCurve::init(Date asof, FXVolatilityCurveSpec spec, const Loader& loade
         longTermDeltaType_ = DeltaVolQuote::DeltaType::Fwd;
         riskReversalInFavorOf_ = Option::Call;
         butterflyIsBrokerStyle_ = true;
+        deltaSwitchTenor_ = 0 * Days;
         spotDays_ = 2;
         string calTmp = sourceCcy_ + "," + targetCcy_;
         spotCalendar_ = parseCalendar(calTmp);
@@ -890,6 +891,7 @@ void FXVolCurve::init(Date asof, FXVolatilityCurveSpec spec, const Loader& loade
             switchTenor_ = fxOptConv->switchTenor();
             riskReversalInFavorOf_ = fxOptConv->riskReversalInFavorOf();
             butterflyIsBrokerStyle_ = fxOptConv->butterflyIsBrokerStyle();
+            deltaSwitchTenor_ = fxOptConv->deltaSwitchTenor();
             if (fxConv) {
                 spotDays_ = fxConv->spotDays();
                 spotCalendar_ = fxConv->advanceCalendar();

--- a/OREData/ored/marketdata/fxvolcurve.cpp
+++ b/OREData/ored/marketdata/fxvolcurve.cpp
@@ -371,7 +371,7 @@ void FXVolCurve::buildSmileBfRrCurve(Date asof, FXVolatilityCurveSpec spec, cons
     vol_ = boost::make_shared<QuantExt::BlackVolatilitySurfaceBFRR>(
         asof, dates, smileDeltasScaled, bfQuotes, rrQuotes, atmQuotes, config->dayCounter(), config->calendar(),
         fxSpot_, spotDays_, spotCalendar_, domYts_, forYts_, deltaType_, atmType_, switchTenor_, longTermDeltaType_,
-        longTermAtmType_, riskReversalInFavorOf_, butterflyIsBrokerStyle_, interp);
+        longTermAtmType_, riskReversalInFavorOf_, butterflyIsBrokerStyle_, interp, deltaSwitchTenor_);
 
     vol_->enableExtrapolation();
 }
@@ -524,7 +524,7 @@ void FXVolCurve::buildVannaVolgaOrATMCurve(Date asof, FXVolatilityCurveSpec spec
 
             vol_ = boost::make_shared<QuantExt::FxBlackVannaVolgaVolatilitySurface>(
                 asof, dates, vols[0], vols[1], vols[2], dc, cal, fxSpot_, domYts_, forYts_, false, vvFirstApprox,
-                atmType_, deltaType_, smileDelta / 100.0, switchTenor_, longTermAtmType_, longTermDeltaType_);
+                atmType_, deltaType_, smileDelta / 100.0, switchTenor_, longTermAtmType_, longTermDeltaType_, deltaSwitchTenor_);
         }
     }
     vol_->enableExtrapolation();

--- a/OREData/ored/marketdata/fxvolcurve.hpp
+++ b/OREData/ored/marketdata/fxvolcurve.hpp
@@ -82,6 +82,7 @@ private:
     QuantLib::DeltaVolQuote::DeltaType longTermDeltaType_;
     QuantLib::Option::Type riskReversalInFavorOf_;
     bool butterflyIsBrokerStyle_;
+    QuantLib::Period deltaSwitchTenor_;
 
     boost::shared_ptr<FxEqCommVolCalibrationInfo> calibrationInfo_;
 

--- a/OREData/test/conventions.cpp
+++ b/OREData/test/conventions.cpp
@@ -351,6 +351,31 @@ BOOST_AUTO_TEST_CASE(testIborConventionConstruction7D) {
     testIborIndexConvention("CNY-REPO-7D", "CNY", "A365F", 2, "MF", true, "CNY-REPO-1W");
 }
 
+BOOST_AUTO_TEST_CASE(testFxOptionConventionFromXml) {
+    BOOST_TEST_MESSAGE("Testing parsing of FXOption convetion from XML");
+
+    // XML string convention
+    string xml;
+    xml.append("<FxOption>");
+    xml.append("  <Id>EUR-USD-FXOPTION</Id>");
+    xml.append("  <FXConventionID>EUR-USD-FX</FXConventionID>");
+    xml.append("  <AtmType>AtmDeltaNeutral</AtmType>");
+    xml.append("  <DeltaType>Spot</DeltaType>");
+    xml.append("  <SwitchTenor>2Y</SwitchTenor>");
+    xml.append("  <LongTermAtmType>AtmDeltaNeutral</LongTermAtmType>");
+    xml.append("  <LongTermDeltaType>Fwd</LongTermDeltaType>");
+    xml.append("  <RiskReversalInFavorOf>Call</RiskReversalInFavorOf>");
+    xml.append("  <ButterflyStyle>Broker</ButterflyStyle>");
+    xml.append("  <DeltaSwitchTenor>2Y</DeltaSwitchTenor>");
+    xml.append("</FxOption>");
+
+    // Parse convention from XML
+    boost::shared_ptr<FxOptionConvention> convention = boost::make_shared<FxOptionConvention>();
+    BOOST_CHECK_NO_THROW(convention->fromXMLString(xml));
+
+    BOOST_CHECK_EQUAL(convention->deltaSwitchTenor(), Period(2, Years));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/OREData/test/conventions.cpp
+++ b/OREData/test/conventions.cpp
@@ -373,6 +373,14 @@ BOOST_AUTO_TEST_CASE(testFxOptionConventionFromXml) {
     boost::shared_ptr<FxOptionConvention> convention = boost::make_shared<FxOptionConvention>();
     BOOST_CHECK_NO_THROW(convention->fromXMLString(xml));
 
+    BOOST_CHECK_EQUAL(convention->fxConventionID(), "EUR-USD-FX");
+    BOOST_CHECK_EQUAL(convention->atmType(), DeltaVolQuote::AtmType::AtmDeltaNeutral);
+    BOOST_CHECK_EQUAL(convention->deltaType(), DeltaVolQuote::DeltaType::Spot);
+    BOOST_CHECK_EQUAL(convention->switchTenor(), Period(2, Years));
+    BOOST_CHECK_EQUAL(convention->longTermAtmType(), DeltaVolQuote::AtmType::AtmDeltaNeutral);
+    BOOST_CHECK_EQUAL(convention->longTermDeltaType(), DeltaVolQuote::DeltaType::Fwd);
+    BOOST_CHECK_EQUAL(convention->riskReversalInFavorOf(), QuantLib::Option::Type::Call);
+    BOOST_CHECK_EQUAL(convention->butterflyIsBrokerStyle(), true);
     BOOST_CHECK_EQUAL(convention->deltaSwitchTenor(), Period(2, Years));
 }
 

--- a/QuantExt/qle/termstructures/blackvolsurfacebfrr.hpp
+++ b/QuantExt/qle/termstructures/blackvolsurfacebfrr.hpp
@@ -52,7 +52,8 @@ public:
         const Period& switchTenor = 2 * Years, const DeltaVolQuote::DeltaType ltdt = DeltaVolQuote::DeltaType::Fwd,
         const DeltaVolQuote::AtmType ltat = DeltaVolQuote::AtmType::AtmDeltaNeutral,
         const Option::Type riskReversalInFavorOf = Option::Call, const bool butterflyIsBrokerStyle = true,
-        const SmileInterpolation smileInterpolation = SmileInterpolation::Cubic);
+        const SmileInterpolation smileInterpolation = SmileInterpolation::Cubic,
+        const Period& deltaSwitchTenor = 0 * Years);
 
     Date maxDate() const override { return Date::maxDate(); }
     Real minStrike() const override { return 0; }
@@ -75,6 +76,7 @@ public:
     Option::Type riskReversalInFavorOf() const { return riskReversalInFavorOf_; }
     bool butterflyIsBrokerStyle() const { return butterflyIsBrokerStyle_; }
     SmileInterpolation smileInterpolation() const { return smileInterpolation_; }
+    const Period& deltaSwitchTenor() const { return deltaSwitchTenor_; }
 
     const std::vector<bool>& smileHasError() const;
     const std::vector<std::string>& smileErrorMessage() const;
@@ -103,8 +105,9 @@ private:
     Option::Type riskReversalInFavorOf_;
     bool butterflyIsBrokerStyle_;
     SmileInterpolation smileInterpolation_;
+    Period deltaSwitchTenor_;
 
-    mutable Real switchTime_, settlDomDisc_, settlForDisc_, settlLag_;
+    mutable Real switchTime_, settlDomDisc_, settlForDisc_, settlLag_, deltaSwitchTime_;
     mutable std::vector<Real> expiryTimes_;
     mutable std::vector<Date> settlementDates_;
     mutable std::vector<Real> currentDeltas_;

--- a/QuantExt/qle/termstructures/blackvolsurfacedelta.hpp
+++ b/QuantExt/qle/termstructures/blackvolsurfacedelta.hpp
@@ -97,7 +97,8 @@ public:
                                 boost::optional<QuantLib::DeltaVolQuote::DeltaType> longTermAtmDeltaType = boost::none,
                                 InterpolatedSmileSection::InterpolationMethod interpolationMethod =
                                     InterpolatedSmileSection::InterpolationMethod::Linear,
-                                bool flatExtrapolation = true);
+                                bool flatExtrapolation = true,
+                                const Period& deltaSwitchTenor = 0 * Days);
 
     //! \name TermStructure interface
     //@{
@@ -154,8 +155,10 @@ private:
 
     InterpolatedSmileSection::InterpolationMethod interpolationMethod_;
     bool flatExtrapolation_;
+    Period deltaSwitchTenor_;
 
     Real switchTime_;
+    Real deltaSwitchTime_;
 
     // calculate forward for time $t$
     Real forward(Time t) const;

--- a/QuantExt/qle/termstructures/fxblackvolsurface.hpp
+++ b/QuantExt/qle/termstructures/fxblackvolsurface.hpp
@@ -49,7 +49,8 @@ public:
                              const DeltaVolQuote::DeltaType deltaType = DeltaVolQuote::DeltaType::Spot,
                              const Real delta = 0.25, const Period& switchTenor = 0 * Days,
                              const DeltaVolQuote::AtmType longTermAtmType = DeltaVolQuote::AtmType::AtmDeltaNeutral,
-                             const DeltaVolQuote::DeltaType longTermDeltaType = DeltaVolQuote::DeltaType::Spot);
+                             const DeltaVolQuote::DeltaType longTermDeltaType = DeltaVolQuote::DeltaType::Spot,
+                             const Period& deltaSwitchTenor = 0 * Days);
 
     //! \name TermStructure interface
     //@{
@@ -95,6 +96,7 @@ protected:
     Interpolation rrCurve_;
     Interpolation bfCurve_;
     Date maxDate_;
+    Period deltaSwitchTenor_;
 };
 
 // inline definitions
@@ -121,9 +123,10 @@ public:
         const DeltaVolQuote::DeltaType deltaType = DeltaVolQuote::DeltaType::Spot, const Real delta = 0.25,
         const Period& switchTenor = 0 * Days,
         const DeltaVolQuote::AtmType longTermAtmType = DeltaVolQuote::AtmType::AtmDeltaNeutral,
-        const DeltaVolQuote::DeltaType longTermDeltaType = DeltaVolQuote::DeltaType::Spot)
+        const DeltaVolQuote::DeltaType longTermDeltaType = DeltaVolQuote::DeltaType::Spot,
+        const Period& deltaSwitchTenor = 0 * Days)
         : FxBlackVolatilitySurface(refDate, dates, atmVols, rr, bf, dc, cal, fx, dom, fore, requireMonotoneVariance,
-                                   atmType, deltaType, delta, switchTenor, longTermAtmType, longTermDeltaType),
+                                   atmType, deltaType, delta, switchTenor, longTermAtmType, longTermDeltaType, deltaSwitchTenor),
           firstApprox_(firstApprox) {}
 
 protected:

--- a/xsd/conventions.xsd
+++ b/xsd/conventions.xsd
@@ -466,6 +466,7 @@
       <xs:element type="xs:string" name="LongTermDeltaType" minOccurs="0"/>
       <xs:element type="xs:string" name="RiskReversalInFavorOf" minOccurs="0"/>
       <xs:element type="xs:string" name="ButterflyStyle" minOccurs="0"/>
+      <xs:element type="xs:string" name="DeltaSwitchTenor" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
 


### PR DESCRIPTION
This pull request introduces a new switch functionality for FX deltas across various volatility surfaces, namely:

- BlackVolatilitySurfaceDelta
- BlackVolatilitySurfaceBFRR
- FxBlackVannaVolgaVolatilitySurface

With the addition of the `DeltaSwitchTenor` parameter, users gain the flexibility to specify different delta conventions based on the option's tenor. When `DeltaSwitchTenor` is provided, the system automatically selects the appropriate delta convention if the option tenor exceeds or equals this specified value, referred to as the "long term" delta type.

For backward compatibility, if `DeltaSwitchTenor` is not provided, the conventional `SwitchTenor` will be utilized for both at-the-money and delta calculations.

This enhancement aims to provide users with enhanced customization options while ensuring seamless integration with existing workflows.