### PR TITLE
Allow toggling extrapolation method for FX delta smiles

### DIFF
--- a/Docs/UserGuide/parameterisation/curveconfig.tex
+++ b/Docs/UserGuide/parameterisation/curveconfig.tex
@@ -162,7 +162,7 @@ Listings \ref{lst:fxoptionvol_configuration_atm}, \ref{lst:fxoptionvol_configura
     <DayCounter>A365</DayCounter>
     <Calendar>US,JP</Calendar>
     <Conventions>USD-JPY-FXOPTION</Conventions>
-    <SmileExtrapolation>Linear</SmileExtrapolation>
+    <SmileExtrapolation>UseInterpolator</SmileExtrapolation>
   </FXVolatility>
 \end{minted}
 \caption{FX option volatility configuration Smile / Delta}
@@ -274,11 +274,10 @@ The meaning of each of the elements in Listings \ref{lst:fxoptionvol_configurati
   data input. See \ref{sss:fx_option_conv} for more details.
 \item BaseVolatility1: For `ATMTriangulated' this denotes one of the surfaces we want to triangulate from
 \item BaseVolatility2: For `ATMTriangulated' this denotes one of the surfaces we want to triangulate from
-\item SmileExtrapolation [Optional]: In case of SmileType Delta. Indicates the extrapolation in the smile direction. The
-allowable values are None, UseInterpolator, Linear and Flat. Both Flat and
-None give flat extrapolation in the smile direction. UseInterpolator and
-Linear indicate that the configured interpolation (linear) should be continued in
-the strike direction in order to extrapolate.
+\item SmileExtrapolation [Optional]: Applicable only in case of SmileType Delta. Indicates the extrapolation in the 
+smile direction. The allowable values are None, UseInterpolator (or Linear) and Flat. Both Flat and None give flat 
+extrapolation. UseInterpolator indicates that the configured interpolation should be continued in the strike 
+direction in order to extrapolate. Default if not provided value is Flat.
 \end{itemize}
 
 \subsubsection{Equity Curve Structures}

--- a/Docs/UserGuide/parameterisation/curveconfig.tex
+++ b/Docs/UserGuide/parameterisation/curveconfig.tex
@@ -162,6 +162,7 @@ Listings \ref{lst:fxoptionvol_configuration_atm}, \ref{lst:fxoptionvol_configura
     <DayCounter>A365</DayCounter>
     <Calendar>US,JP</Calendar>
     <Conventions>USD-JPY-FXOPTION</Conventions>
+    <SmileExtrapolation>Linear</SmileExtrapolation>
   </FXVolatility>
 \end{minted}
 \caption{FX option volatility configuration Smile / Delta}
@@ -273,6 +274,11 @@ The meaning of each of the elements in Listings \ref{lst:fxoptionvol_configurati
   data input. See \ref{sss:fx_option_conv} for more details.
 \item BaseVolatility1: For `ATMTriangulated' this denotes one of the surfaces we want to triangulate from
 \item BaseVolatility2: For `ATMTriangulated' this denotes one of the surfaces we want to triangulate from
+\item SmileExtrapolation [Optional]: In case of SmileType Delta. Indicates the extrapolation in the smile direction. The
+allowable values are None, UseInterpolator, Linear and Flat. Both Flat and
+None give flat extrapolation in the smile direction. UseInterpolator and
+Linear indicate that the configured interpolation (linear) should be continued in
+the strike direction in order to extrapolate.
 \end{itemize}
 
 \subsubsection{Equity Curve Structures}

--- a/OREData/ored/configuration/fxvolcurveconfig.cpp
+++ b/OREData/ored/configuration/fxvolcurveconfig.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -33,11 +34,11 @@ FXVolatilityCurveConfig::FXVolatilityCurveConfig(const string& curveID, const st
                                                  const string& fxForeignCurveID, const string& fxDomesticCurveID,
                                                  const DayCounter& dayCounter, const Calendar& calendar,
                                                  const SmileInterpolation& interp, const string& conventionsID,
-                                                 const std::vector<Size>& smileDelta)
+                                                 const std::vector<Size>& smileDelta, const string& smileExtrapolation)
     : CurveConfig(curveID, curveDescription), dimension_(dimension), expiries_(expiries), dayCounter_(dayCounter),
       calendar_(calendar), fxSpotID_(fxSpotID), fxForeignYieldCurveID_(fxForeignCurveID),
       fxDomesticYieldCurveID_(fxDomesticCurveID), conventionsID_(conventionsID), smileDelta_(smileDelta),
-      smileInterpolation_(interp) {
+      smileInterpolation_(interp), smileExtrapolation_(smileExtrapolation) {
     populateRequiredCurveIds();
 }
 
@@ -134,7 +135,7 @@ void FXVolatilityCurveConfig::fromXML(XMLNode* node) {
                     smileDelta_ = parseListOfValues<Size>(sDelta, &parseInteger);
             } else if (smileType == "Delta") {
                 dimension_ = Dimension::SmileDelta;
-                // only read smile interpolation method if dimension is smile.
+                // only read smile interpolation and extrapolation method if dimension is smile.
                 if (smileInterp == "" || smileInterp == "Linear") {
                     smileInterpolation_ = SmileInterpolation::Linear;
                 } else if (smileInterp == "Cubic") {
@@ -142,6 +143,9 @@ void FXVolatilityCurveConfig::fromXML(XMLNode* node) {
                 } else {
                     QL_FAIL("SmileInterpolation " << smileInterp << " not supported");
                 }
+
+                smileExtrapolation_ = XMLUtils::getChildValue(node, "SmileExtrapolation", false, "Flat");
+
                 deltas_ = XMLUtils::getChildrenValuesAsStrings(node, "Deltas", true);
 
                 // check that these are valid deltas
@@ -235,6 +239,8 @@ XMLNode* FXVolatilityCurveConfig::toXML(XMLDocument& doc) {
         } else {
             QL_FAIL("Unknown SmileInterpolation in FXVolatilityCurveConfig::toXML()");
         }
+        if (!smileExtrapolation_.empty())
+            XMLUtils::addChild(doc, node, "SmileExtrapolation", smileExtrapolation_);
         XMLUtils::addChild(doc, node, "Conventions", to_string(conventionsID_));
         XMLUtils::addGenericChildAsList(doc, node, "Deltas", deltas_);
     } else if (dimension_ == Dimension::SmileBFRR) {

--- a/OREData/ored/configuration/fxvolcurveconfig.hpp
+++ b/OREData/ored/configuration/fxvolcurveconfig.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -72,7 +73,8 @@ public:
                             const DayCounter& dayCounter = QuantLib::Actual365Fixed(),
                             const Calendar& calendar = QuantLib::TARGET(),
                             const SmileInterpolation& interp = SmileInterpolation::VannaVolga2,
-                            const string& conventionsID = "", const std::vector<Size>& smileDelta = {25});
+                            const string& conventionsID = "", const std::vector<Size>& smileDelta = {25},
+                            const string& smileExtrapolation = "Flat");
 
     FXVolatilityCurveConfig(const string& curveID, const string& curveDescription, const Dimension& dimension,
                             const string& baseVolatility1, const string& baseVolatility2,
@@ -98,6 +100,7 @@ public:
     const string& fxForeignYieldCurveID() const { return fxForeignYieldCurveID_; }
     const string& fxDomesticYieldCurveID() const { return fxDomesticYieldCurveID_; }
     const SmileInterpolation& smileInterpolation() const { return smileInterpolation_; }
+    const std::string& smileExtrapolation() const { return smileExtrapolation_; }
     const string& conventionsID() const { return conventionsID_; }
     const std::vector<Size>& smileDelta() const { return smileDelta_; }
     const vector<string>& quotes() override;
@@ -111,6 +114,7 @@ public:
     //@{
     Dimension& dimension() { return dimension_; }
     SmileInterpolation& smileInterpolation() { return smileInterpolation_; }
+    string& smileExtrapolation() { return smileExtrapolation_; }
     vector<string>& deltas() { return deltas_; }
     DayCounter& dayCounter() { return dayCounter_; }
     Calendar& calendar() { return calendar_; }
@@ -140,6 +144,7 @@ private:
     std::vector<Size> smileDelta_;
     std::set<string> requiredYieldCurveIDs_;
     SmileInterpolation smileInterpolation_;
+    string smileExtrapolation_;
     string baseVolatility1_;
     string baseVolatility2_;
     string fxIndexTag_;

--- a/xsd/curveconfig.xsd
+++ b/xsd/curveconfig.xsd
@@ -158,7 +158,7 @@
       <xs:element type="xs:string" name="FXIndexTag" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:string" name="BaseVolatility1" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:string" name="BaseVolatility2" minOccurs="0" maxOccurs="1"/>
-      <xs:element type="reportConfiguration" name="Report" minOccurs="0"/>
+      <xs:element type="extrapolationType" name="SmileExtrapolation" minOccurs="0" maxOccurs="1"/>
     </xs:all>
   </xs:complexType>
 

--- a/xsd/curveconfig.xsd
+++ b/xsd/curveconfig.xsd
@@ -158,6 +158,7 @@
       <xs:element type="xs:string" name="FXIndexTag" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:string" name="BaseVolatility1" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:string" name="BaseVolatility2" minOccurs="0" maxOccurs="1"/>
+      <xs:element type="reportConfiguration" name="Report" minOccurs="0"/>
       <xs:element type="extrapolationType" name="SmileExtrapolation" minOccurs="0" maxOccurs="1"/>
     </xs:all>
   </xs:complexType>


### PR DESCRIPTION
Hi,
We find it useful to allow toggling the extrapolation method, which currently would default to 'Flat' for delta skews. The code changes here are borrowed from the commodity delta volatility implementation, following the same logic.

I'll mark the PR as ready once we've extended the docs and XSDs.

Thanks!
Fredrik