### PR TITLE
Fix root cause issue with PR #209

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -232,6 +232,27 @@
       "generator": "Unix Makefiles"
     },
     {
+      "name": "windows-msvc-x64-debug",
+      "inherits": [
+        "windows-msvc-x64",
+        "_debug"
+      ]
+    },
+    {
+      "name": "windows-msvc-x64-release",
+      "inherits": [
+        "windows-msvc-x64",
+        "_release"
+      ]
+    },
+    {
+      "name": "windows-msvc-x64-relWithDebInfo",
+      "inherits": [
+        "windows-msvc-x64",
+        "_relwithdebinfo"
+      ]
+    },
+    {
       "name": "linux-gcc-ninja-debug",
       "inherits": [
         "linux-gcc-base",
@@ -349,7 +370,7 @@
     },
     {
       "name": "windows-msvc-x64-release",
-      "configurePreset": "windows-msvc-x64",
+      "configurePreset": "windows-msvc-x64-release",
       "configuration": "Release",
       "nativeToolOptions": [
         "-m"
@@ -357,7 +378,7 @@
     },
     {
       "name": "windows-msvc-x64-relWithDebInfo",
-      "configurePreset": "windows-msvc-x64",
+      "configurePreset": "windows-msvc-x64-relWithDebInfo",
       "configuration": "RelWithDebInfo",
       "nativeToolOptions": [
         "-m"
@@ -365,7 +386,7 @@
     },
     {
       "name": "windows-msvc-x64-debug",
-      "configurePreset": "windows-msvc-x64",
+      "configurePreset": "windows-msvc-x64-debug",
       "configuration": "Debug",
       "nativeToolOptions": [
         "-m"


### PR DESCRIPTION
We have identified the root cause for the Windows debug issue related to revert of PR #209, specifically the linking mismatch between `MD` and `MDd` with Boost. The issue arises because `CMAKE_BUILD_TYPE` was not correctly configured. `CMAKE_BUILD_TYPE` is a CMake configuration-time variable that should be defined in the configurePresets section of the `CMakePresets.json` file, not in the buildPresets section.

Currently, the configurePreset does not specify `CMAKE_BUILD_TYPE`, which leads to the following lines failing when linking with Boost:

```
if(CMAKE_BUILD_TYPE MATCHES Release)
    set(Boost_USE_DEBUG_LIBS OFF)
    set(Boost_USE_RELEASE_LIBS ON)
elseif(CMAKE_BUILD_TYPE MATCHES Debug)
    set(Boost_USE_DEBUG_LIBS ON)
    set(Boost_USE_RELEASE_LIBS OFF)
endif()
```

As `CMAKE_BUILD_TYPE` is empty, this condition results in linking with Boost release libraries when building the application in debug mode, causing a linker error with the output "mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match 'MDd_DynamicDebug'".

To resolve this, `CMAKE_BUILD_TYPE` should be specified in the configurePresets section.
This will ensure that the correct Boost libraries are linked based on the build type.

Furthermore, PR #209 is crucial as it ensures the static linking option on Linux. Currently, Linux artifacts are always dynamically linked regardless of the `BUILD_SHARED_LIBS` setting, as shown by the output of the ldd command on the ore binary:

```
$ ldd ore
    linux-vdso.so.1 (0x00007ffc35b0c000)
    libboost_regex.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_regex.so.1.74.0 (0x00007fc7e9536000)
    libboost_serialization.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_serialization.so.1.74.0 (0x00007fc7e94f4000)
    libboost_filesystem.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_filesystem.so.1.74.0 (0x00007fc7e94d4000)
    libboost_timer.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_timer.so.1.74.0 (0x00007fc7e94ca000)
    libboost_log.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_log.so.1.74.0 (0x00007fc7e941e000)
    libboost_thread.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0 (0x00007fc7e93fa000)
    ...
```

We highly recommend merging PR #209 (revert the revert) as it will address the dynamic linking issue on Linux and ensure the proper configuration for Windows builds.

Thank you for considering this update.
kohnech