### PR TITLE
Docker release flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# When hacking the build process, we don't want to totally rebuild if we can help it
+.github
+test-results

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -22,6 +22,7 @@ on:
       - ./QuantExt/**
       - '!./QuantExt/doc/**'
       - CMakeLists.txt
+      - Docker/Dockerfile.aio.*
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -111,7 +111,7 @@ jobs:
           tags: ore-builder
           target: builder
           cache-from: ${{ fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_from }}
-          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_to }}
+          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_to || '' }}
 
       # Run the tests inside the container we just build, saving the results to our workspace
       - name: Create test-results folder
@@ -172,4 +172,4 @@ jobs:
           tags: ${{ steps.release-meta.outputs.tags }}
           labels: ${{ steps.release-meta.outputs.labels }}
           cache-from: ${{ fromJSON(steps.release-tag-cache-mapper.outputs.result).cache_from }}
-          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.release-tag-cache-mapper.outputs.result).cache_to }}
+          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.release-tag-cache-mapper.outputs.result).cache_to || '' }}

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -1,0 +1,174 @@
+name: Build container image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags:
+        - 'v*'
+  release:
+    types: [published]
+  pull_request:
+    branches: [master]
+    types: [ready_for_review, opened, synchronize, reopened]
+    paths:
+      - .github/workflows/linux_build.yaml
+      - ./App/**
+      - ./OREAnalytics/**
+      - '!./OREAnalytics/doc/**'
+      - ./OREData/**
+      - '!./OREData/doc/**'
+      - ./ORETest/**
+      - ./QuantExt/**
+      - '!./QuantExt/doc/**'
+      - CMakeLists.txt
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-release:
+    strategy:
+      matrix:
+        flavour: [debian11, centos_stream9]
+        platform: [linux/amd64]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log into registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      # This looks overworked but it gives us limited flexibility to add new flavours without having to overduplicate Dockerfiles
+      - name: Config
+        id: config
+        uses: cloudposse/github-action-yaml-config-query@main      
+        with:
+          query: .${{ matrix.flavour }}
+          config: |-
+            debian11:
+              dockerfile_suffix: debian11
+              tag_prefix: debian11
+            centos_stream9:
+              dockerfile_suffix: centos-stream9
+              tag_prefix: centos-stream9
+          # Fully-defined example
+          # centos_stream9:
+          #   dockerfile_suffix: centos-stream9
+          #   tag_prefix: centos-stream9  
+          # build_args: |
+          #   builder_base_image=quay.io/centos/centos:stream9
+          #   release_base_image=quay.io/centos/centos:stream9-minimal
+          #   code_ready_builder_repo=crb
+
+      # use registry caching to make this faster
+      # https://blacksmith.sh/blog/cache-is-king-a-guide-for-docker-layer-caching-in-github-actions
+
+      # Build the first stage, which we can use as the testing facility    
+      - name: Extract metadata (tags, labels) for the builder
+        id: builder-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-builder
+          flavor: |
+            latest=false
+            prefix=${{ steps.config.outputs.tag_prefix }}-,onlatest=true
+          tags: |
+            type=sha,prefix=${{ steps.config.outputs.tag_prefix }}-sha-
+            type=ref,event=branch
+            type=ref,event=tag
+      - name: Map builder tags to cache specs
+        uses: actions/github-script@v7
+        id: builder-tag-cache-mapper
+        env:
+          TAGS: ${{ steps.builder-meta.outputs.tags }}
+        with:
+          script: |
+            return {
+              cache_from: process.env.TAGS.split("\n").map(t=>'type=registry,ref='+ t).join("\n"),
+              cache_to: process.env.TAGS.split("\n").map(t=>'type=registry,ref='+ t + ',mode=max').join("\n")
+            }
+
+      - name: Build the "builder" container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          file: ./Docker/Dockerfile.aio.${{ steps.config.outputs.dockerfile_suffix }}
+          build-args: ${{ steps.config.outputs.build_args }}
+          platforms: ${{ matrix.platform }}
+          tags: ore-builder
+          target: builder
+          cache-from: ${{ fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_from }}
+          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_to }}
+
+      # Run the tests inside the container we just build, saving the results to our workspace
+      - name: Create test-results folder
+        run: mkdir -p test-results
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v2
+        id: cpu-cores
+      - name: Run the tests
+        run: >
+          /usr/bin/docker run
+          --workdir=/ore/build --volume $GITHUB_WORKSPACE/test-results:/ore/test-results
+          --env NOSE_PROCESSES=${{ steps.cpu-cores.outputs.count }} --env NOSE_PROCESS_TIMEOUT=600 --env NOSE_WITH_XUNITMP=true --env NOSE_XUNITMP_FILE=/ore/test-results/examples.xml
+          ore-builder
+          ctest -j${{ steps.cpu-cores.outputs.count }} --test-dir . --output-junit /ore/test-results/ctest.xml --timeout 5400
+
+      # Register the xunit results
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        # only if the tests ran - there are other results for skipped, etc.
+        if: success() || failure()
+        with:
+          files: |
+            test-results/**/*.xml
+
+      # Build the rest of the stages - the first stage should be cached
+      - name: Extract metadata (tags, labels) for Docker release
+        id: release-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+            prefix=${{ steps.config.outputs.tag_prefix }}-,onlatest=true
+          tags: |
+            type=sha,prefix=${{ steps.config.outputs.tag_prefix }}-sha-
+            type=ref,event=branch
+            type=ref,event=tag
+      - name: Map release tags to cache specs
+        uses: actions/github-script@v7
+        id: release-tag-cache-mapper
+        env:
+          TAGS: ${{ steps.builder-meta.outputs.tags }}
+        with:
+          script: |
+            return {
+              cache_from: process.env.TAGS.split("\n").map(t=>'type=registry,ref='+ t).join("\n"),
+              cache_to: process.env.TAGS.split("\n").map(t=>'type=registry,ref='+ t + ',mode=max').join("\n")
+            }
+            
+      - name: Build the "release" container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Docker/Dockerfile.aio.${{ steps.config.outputs.dockerfile_suffix }}
+          build-args: ${{ steps.config.outputs.build_args }}
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.release-meta.outputs.tags }}
+          labels: ${{ steps.release-meta.outputs.labels }}
+          cache-from: ${{ fromJSON(steps.release-tag-cache-mapper.outputs.result).cache_from }}
+          cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.release-tag-cache-mapper.outputs.result).cache_to }}

--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -113,7 +113,7 @@ jobs:
           cache-from: ${{ fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_from }}
           cache-to: ${{ (github.event_name != 'pull_request') && fromJSON(steps.builder-tag-cache-mapper.outputs.result).cache_to || '' }}
 
-      # Run the tests inside the container we just build, saving the results to our workspace
+      # Run the tests inside the container we just built, saving the results to our workspace
       - name: Create test-results folder
         run: mkdir -p test-results
       - name: Get number of CPU cores

--- a/Docker/Dockerfile.aio.centos-stream9
+++ b/Docker/Dockerfile.aio.centos-stream9
@@ -93,4 +93,4 @@ ENV PATH=/ore/bin:$PATH
 # Adjust the locale so 1,000 comma separators are suppressed
 ENV LC_NUMERIC=C
 
-CMD /ore/bin/ore
+ENTRYPOINT ["/ore/bin/ore"]

--- a/Docker/Dockerfile.aio.centos-stream9
+++ b/Docker/Dockerfile.aio.centos-stream9
@@ -1,0 +1,96 @@
+ARG builder_base_image=quay.io/centos/centos:stream9
+ARG release_base_image=quay.io/centos/centos:stream9-minimal
+
+#
+# builder image
+#
+FROM ${builder_base_image} AS builder
+
+# the name of the Code Ready Builder repository (contains eigen3)
+ARG code_ready_builder_repo=crb
+
+# Set to override number of build jobs. Will default to number of cores available.
+ARG build_jobs=
+ARG cmake_build_type=Release
+
+COPY CMakeLists.txt /ore/CMakeLists.txt
+COPY QuantLib /ore/QuantLib
+COPY QuantExt /ore/QuantExt
+COPY OREData /ore/OREData
+COPY OREAnalytics /ore/OREAnalytics
+COPY App /ore/App
+COPY ThirdPartyLibs /ore/ThirdPartyLibs
+COPY ORETest /ore/ORETest
+COPY cmake /ore/cmake
+
+# Install dependencies
+RUN yum -q -y clean expire-cache \
+  && yum -q -y update \
+  && yum -q -y --enablerepo=${code_ready_builder_repo} install \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    # Example_43 requires this https://github.com/OpenSourceRisk/Engine/issues/142
+    eigen3-devel \
+    gcc \
+    gcc-c++ \
+    glibc-devel \
+    ninja-build \
+    ocl-icd-devel \
+    opencl-headers \
+    zlib-devel
+
+# set up the build
+RUN cd / \
+  && mkdir -p /ore/build && cd /ore/build \
+  && cmake /ore -GNinja -DCMAKE_BUILD_TYPE=${cmake_build_type} -DORE_BUILD_DOC=OFF -DORE_USE_ZLIB=ON -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=ON -DORE_ENABLE_OPENCL=ON
+
+# build
+RUN cd /ore/build \
+  && cmake --build . -- -j${build_jobs:-$(nproc)} install
+
+RUN ldconfig
+
+# test facility
+# Set up the Python 3.9 venv so nose works.  Migration from nose seems needed
+RUN yum -q -y install python3.9 python3-pip 
+ENV VIRTUAL_ENV=/opt/python3.9-venv
+RUN python3.9 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install \
+    datacompy \
+    jsondiff \
+    lxml \
+    matplotlib \
+    pandas \
+    nose \
+    nose_xunitmp \
+    xmldiff
+
+COPY Examples /ore/Examples
+COPY Tools /ore/Tools
+
+#
+# release image
+#
+FROM ${release_base_image} AS release
+
+LABEL org.opencontainers.image.authors="Quaternion Risk Management"
+LABEL org.opencontainers.image.description="Open Source Risk Engine"
+
+# libs to run
+RUN microdnf install -y boost ocl-icd --nodocs && \
+    microdnf clean all -y
+
+# fetch built files from orebuild - we use a bind mount to allow us to copy library symlinks
+RUN mkdir -p /ore/bin /ore/lib
+RUN --mount=type=bind,from=builder,source=/usr/local,target=/orebuild cp -a /orebuild/bin/ore /ore/bin && cp -a /orebuild/lib/lib*.so* /ore/lib
+
+# tell the linker where the libraries are, as the relative directories are no longer valid
+ENV LD_LIBRARY_PATH=/ore/lib
+# ensure ore is on the PATH so that if a interactive terminal is used, it's easily findable
+ENV PATH=/ore/bin:$PATH
+# Adjust the locale so 1,000 comma separators are suppressed
+ENV LC_NUMERIC=C
+
+CMD /ore/bin/ore

--- a/Docker/Dockerfile.aio.debian11
+++ b/Docker/Dockerfile.aio.debian11
@@ -112,4 +112,4 @@ ENV PATH=/ore/bin:$PATH
 # Adjust the locale so 1,000 comma separators are suppressed
 ENV LC_NUMERIC=C
 
-CMD /ore/bin/ore
+ENTRYPOINT ["/ore/bin/ore"]

--- a/Docker/Dockerfile.aio.debian11
+++ b/Docker/Dockerfile.aio.debian11
@@ -1,0 +1,115 @@
+ARG debian_tag=11
+
+#
+# builder image
+#
+FROM debian:${debian_tag} AS builder
+
+# Set to override number of build jobs. Will default to number of cores available.
+ARG build_jobs=
+ARG cmake_build_type=Release
+
+COPY CMakeLists.txt /ore/CMakeLists.txt
+COPY QuantLib /ore/QuantLib
+COPY QuantExt /ore/QuantExt
+COPY OREData /ore/OREData
+COPY OREAnalytics /ore/OREAnalytics
+COPY App /ore/App
+COPY ThirdPartyLibs /ore/ThirdPartyLibs
+COPY ORETest /ore/ORETest
+COPY cmake /ore/cmake
+
+# Install dependencies
+RUN apt-get -qq update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y \
+    autoconf \
+    build-essential \
+    ccache \
+    cmake \
+    doxygen \
+    graphviz \
+    libboost-all-dev \
+    libbz2-dev \
+    libeigen3-dev \
+    libtool \
+    ninja-build \
+    ocl-icd-opencl-dev \
+    opencl-headers \
+    zlib1g-dev \
+  && apt-get clean
+
+# set up the build
+RUN cd / \
+  && mkdir -p /ore/build && cd /ore/build \
+  && cmake /ore -GNinja -DCMAKE_BUILD_TYPE=${cmake_build_type} -DORE_BUILD_DOC=OFF -DORE_USE_ZLIB=ON -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=ON -DORE_ENABLE_OPENCL=ON
+
+# build
+RUN cd /ore/build \
+  && cmake --build . -- -j${build_jobs:-$(nproc)} install
+
+RUN ldconfig
+
+# test facility
+# Set up the Python 3.9 venv so nose works.  Migration from nose seems needed
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && apt-get -qq install -y \
+    python3.9 \
+    python3-pip \
+    python3-venv \
+  && apt-get clean
+
+ENV VIRTUAL_ENV=/opt/python3.9-venv
+RUN python3.9 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install \
+    datacompy \
+    jsondiff \
+    lxml \
+    matplotlib \
+    pandas \
+    nose \
+    nose_xunitmp \
+    xmldiff
+
+COPY Examples /ore/Examples
+COPY Tools /ore/Tools
+
+#
+# release image
+#
+FROM debian:${debian_tag}-slim AS release
+
+LABEL org.opencontainers.image.authors="Quaternion Risk Management"
+LABEL org.opencontainers.image.description="Open Source Risk Engine"
+
+ARG boostver="1.74.0"
+
+# libs to run
+RUN apt-get -qq update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y \
+      ocl-icd-libopencl1 \
+      libboost-atomic${boostver} \
+      libboost-chrono${boostver} \
+      libboost-date-time${boostver} \
+      libboost-filesystem${boostver} \
+      libboost-iostreams${boostver} \
+      libboost-log${boostver} \
+      libboost-regex${boostver} \
+      libboost-serialization${boostver} \
+      libboost-system${boostver} \
+      libboost-thread${boostver} \
+      libboost-timer${boostver} \
+      libboost-test${boostver} \
+    && apt-get clean
+
+# fetch built files from orebuild - we use a bind mount to allow us to copy library symlinks
+RUN mkdir -p /ore/bin /ore/lib
+RUN --mount=type=bind,from=builder,source=/usr/local,target=/orebuild cp -a /orebuild/bin/ore /ore/bin && cp -a /orebuild/lib/lib*.so* /ore/lib
+
+# tell the linker where the libraries are, as the relative directories are no longer valid
+ENV LD_LIBRARY_PATH=/ore/lib
+# ensure ore is on the PATH so that if a interactive terminal is used, it's easily findable
+ENV PATH=/ore/bin:$PATH
+# Adjust the locale so 1,000 comma separators are suppressed
+ENV LC_NUMERIC=C
+
+CMD /ore/bin/ore

--- a/Docker/Dockerfile.aio.fedora40
+++ b/Docker/Dockerfile.aio.fedora40
@@ -1,0 +1,91 @@
+ARG fedora_tag=40
+
+#
+# orebuild
+#
+FROM registry.fedoraproject.org/fedora:${fedora_tag} AS builder
+
+# Set to override number of build jobs. Will default to number of cores available.
+ARG build_jobs=
+ARG cmake_build_type=Release
+
+COPY CMakeLists.txt /ore/CMakeLists.txt
+COPY QuantLib /ore/QuantLib
+COPY QuantExt /ore/QuantExt
+COPY OREData /ore/OREData
+COPY OREAnalytics /ore/OREAnalytics
+COPY App /ore/App
+COPY ThirdPartyLibs /ore/ThirdPartyLibs
+COPY ORETest /ore/ORETest
+COPY cmake /ore/cmake
+
+# Install dependencies
+RUN yum -q -y clean expire-cache && yum -q -y update && yum -q -y install \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    # Example_43 requires this https://github.com/OpenSourceRisk/Engine/issues/142
+    eigen3-devel \
+    gcc \
+    gcc-c++ \
+    glibc-devel \
+    ninja-build \
+    ocl-icd-devel \
+    opencl-headers \
+    # zlib is (currently) provided by zlib-ng in fedora40
+    zlib-ng-compat-devel
+
+# set up the build
+RUN cd / \
+  && mkdir -p /ore/build && cd /ore/build \
+  && cmake /ore -GNinja -DCMAKE_BUILD_TYPE=${cmake_build_type} -DORE_BUILD_DOC=OFF -DORE_USE_ZLIB=ON -DQL_BUILD_EXAMPLES=false -DQL_BUILD_TEST_SUITE=false -DQL_BUILD_BENCHMARK=false -DQL_ENABLE_SESSIONS=ON -DORE_ENABLE_OPENCL=ON
+
+# build
+RUN cd /ore/build \
+  && cmake --build . -- -j${build_jobs:-$(nproc)} install
+
+RUN ldconfig
+
+# test facility
+# Set up the Python 3.9 venv so nose works.  Migration from nose seems needed
+RUN yum -q -y install python3.9 python3-pip 
+ENV VIRTUAL_ENV=/opt/python3.9-venv
+RUN python3.9 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install \
+    datacompy \
+    jsondiff \
+    lxml \
+    matplotlib \
+    pandas \
+    nose \
+    nose_xunitmp \
+    xmldiff
+
+COPY Examples /ore/Examples
+COPY Tools /ore/Tools
+
+#
+# release image
+#
+FROM registry.fedoraproject.org/fedora-minimal:${fedora_tag} AS release
+
+LABEL org.opencontainers.image.authors="Quaternion Risk Management"
+LABEL org.opencontainers.image.description="Open Source Risk Engine"
+
+# libs to run
+RUN microdnf install -y boost ocl-icd --nodocs && \
+    microdnf clean all -y
+
+# fetch built files from orebuild - we use a bind mount to allow us to copy library symlinks
+RUN mkdir -p /ore/bin /ore/lib
+RUN --mount=type=bind,from=builder,source=/usr/local,target=/orebuild cp -a /orebuild/bin/ore /ore/bin && cp -a /orebuild/lib/lib*.so* /ore/lib
+
+# tell the linker where the libraries are, as the relative directories are no longer valid
+ENV LD_LIBRARY_PATH=/ore/lib
+# ensure ore is on the PATH so that if a interactive terminal is used, it's easily findable
+ENV PATH=/ore/bin:$PATH
+# Adjust the locale so 1,000 comma separators are suppressed
+ENV LC_NUMERIC=C
+
+CMD /ore/bin/ore

--- a/Docker/Dockerfile.aio.fedora40
+++ b/Docker/Dockerfile.aio.fedora40
@@ -88,4 +88,4 @@ ENV PATH=/ore/bin:$PATH
 # Adjust the locale so 1,000 comma separators are suppressed
 ENV LC_NUMERIC=C
 
-CMD /ore/bin/ore
+ENTRYPOINT ["/ore/bin/ore"]

--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -624,6 +624,33 @@ checking out the source code from the github repository as described in section 
 ORE releases are regularly provided in the form of source code archives, Windows exe\-cutables {\tt ore.exe}, example
 cases and documentation. Release archives will be provided at \url{https://github.com/opensourcerisk/engine/releases}.
 
+\subsubsection{Linux container images}
+
+We build and release a container image, which includes the necessary libraries and binaries. \\
+
+\medskip
+Usage example: \\
+
+\medskip
+{\tt docker run ghcr.io/OpenSourceRisk/ore-engine:centos-stream9-latest [<ore\_argument> ...] } \\
+
+\medskip
+Other tags and versions are available, see \url{https://github.com/OpenSourceRisk/Engine/pkgs/container/ore-engine/versions?filters\%5Bversion_type\%5D=tagged} \\
+
+\medskip
+If you need to bring in files from your container host, then use a container volume to mount a host directory into the running container: \\
+
+\medskip
+{\tt docker run -v <host\_dir>:<container\_dir> ghcr.io/OpenSourceRisk/ore-engine:centos-stream9-latest [<ore\_argument> ...] } \\
+
+\medskip
+For example, this command can be used to run a single example from the {\tt Examples} directory: \\
+
+\medskip
+{\tt docker run -v <workspace>/Examples:/ore/Examples -i -t -w /ore/Examples/Example\_1 ghcr.io/OpenSourceRisk/ore-engine:centos-stream9-latest /ore/bin/ore Input/ore.xml } \\
+
+\subsubsection{Windows binaries}
+
 The release contains the QuantLib source version that ORE depends on. This is the latest QuantLib release that precedes the ORE release including a small number of patches.
 
 \medskip

--- a/Docs/UserGuide/userguide.tex
+++ b/Docs/UserGuide/userguide.tex
@@ -647,7 +647,7 @@ If you need to bring in files from your container host, then use a container vol
 For example, this command can be used to run a single example from the {\tt Examples} directory: \\
 
 \medskip
-{\tt docker run -v <workspace>/Examples:/ore/Examples -i -t -w /ore/Examples/Example\_1 ghcr.io/OpenSourceRisk/ore-engine:centos-stream9-latest /ore/bin/ore Input/ore.xml } \\
+{\tt docker run -v <workspace>/Examples:/ore/Examples -i -t -w /ore/Examples/Example\_1 ghcr.io/OpenSourceRisk/ore-engine:centos-stream9-latest Input/ore.xml } \\
 
 \subsubsection{Windows binaries}
 

--- a/Examples/ore_examples_helper.py
+++ b/Examples/ore_examples_helper.py
@@ -77,6 +77,10 @@ class OreExample(object):
             elif os.path.isfile("../../../build/ore/App/ore"):
                 self.ore_exe = "../../../build/ore/App/ore"
                 self.ore_plus_exe = "../../../build/AppPlus/ore_plus"
+            elif shutil.which("ore"):
+                # Look on the PATH to see if the executable is there
+                self.ore_exe = shutil.which("ore")
+                print_on_console("Using ORE executable found on PATH")
             else:
                 print_on_console("ORE executable not found.")
                 quit()


### PR DESCRIPTION
Build, test and release process for `linux/amd64` container images, in two flavours:
* Debian 11
* CentOS Stream 9
* Fedora 40 (disabled in GHA)

I investigated moving to Debian 12, but the complexity of managing the Python `nose` dependency after Python v3.9 makes this a much bigger task.  So we're limited to Debian 11 for now, or at least until someone Python skilled puts the effort in there.

CentOS Stream 9 will allow users to build RHEL 9 container images (and gain support for the stack) if they wish, but distributing these images is tricky without further discussions, so I haven't put that logic into the GHA workflow (yet).