### PR TITLE
fix the wildcard generation for discount curves

### DIFF
--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -1118,7 +1118,7 @@ void YieldCurve::buildDiscountCurve() {
         marketData = loader_.get(*wildcard, asofDate_);
     } else {
         std::ostringstream ss;
-        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/*";
+        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/" << curveConfig_->curveID() << "/*";
         Wildcard w(ss.str());
         marketData = loader_.get(w, asofDate_);
     }


### PR DESCRIPTION
added missing information on the curveID in the wildcarding as needed… in case of more than one curve in the same currency all market data points from all curves in the same currency will be collected which is not correct as only the points with the particular curve id needed. 