### PR TITLE
Feature/handlying of roll convention

### DIFF
--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -1118,7 +1118,7 @@ void YieldCurve::buildDiscountCurve() {
         marketData = loader_.get(*wildcard, asofDate_);
     } else {
         std::ostringstream ss;
-        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/*";
+        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/" << curveConfig_->curveID() << "/*";
         Wildcard w(ss.str());
         marketData = loader_.get(w, asofDate_);
     }


### PR DESCRIPTION
In cases where there are close tenors (e.g., 2D and 3D) in the aliases of a discount curve configuration, the calendar and roll convention may result in both tenors being mapped to the same date in the date map. Consequently, the number of entries in the date map may be lower than the number of quotes in the quotes vector. This discrepancy leads to a QL_REQUIRE condition evaluating to TRUE, preventing the curve from being built and the code being further processed. The PR avoids this behavior.