### PR TITLE
mirror notional payment lag from coupon payment lag

### DIFF
--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -1118,7 +1118,7 @@ void YieldCurve::buildDiscountCurve() {
         marketData = loader_.get(*wildcard, asofDate_);
     } else {
         std::ostringstream ss;
-        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/*";
+        ss << MarketDatum::InstrumentType::DISCOUNT << "/" << MarketDatum::QuoteType::RATE << "/" << currency_ << "/" << curveConfig_->curveID() << "/*";
         Wildcard w(ss.str());
         marketData = loader_.get(w, asofDate_);
     }

--- a/OREData/ored/portfolio/legdata.cpp
+++ b/OREData/ored/portfolio/legdata.cpp
@@ -813,6 +813,15 @@ void LegData::fromXML(XMLNode* node) {
     if (auto tmp = XMLUtils::getChildNode(node, "ScheduleData"))
         schedule_.fromXML(tmp);
 
+    // set payment calendar equal to the schedule calendar if the payment calendar not given
+    // otherwise the payment calendar is not set and payments of notional can happen before the interest payments 
+    if (paymentCalendar_.empty()) {
+        auto tmp = schedule_.rules().front().calendar();
+        if (!tmp.empty()) {
+            paymentCalendar_ = tmp;
+        }
+    }
+
     paymentDates_ = XMLUtils::getChildrenValues(node, "PaymentDates", "PaymentDate", false);
     if (!paymentDates_.empty()) {
         WLOG("Usage of PaymentDates is deprecated, use PaymentSchedule instead.");

--- a/OREData/ored/portfolio/legdata.cpp
+++ b/OREData/ored/portfolio/legdata.cpp
@@ -764,7 +764,7 @@ void LegData::fromXML(XMLNode* node) {
     dayCounter_ = XMLUtils::getChildValue(node, "DayCounter"); // optional
     paymentConvention_ = XMLUtils::getChildValue(node, "PaymentConvention");
     paymentLag_ = XMLUtils::getChildValue(node, "PaymentLag");
-    notionalPaymentLag_ = XMLUtils::getChildValue(node, "NotionalPaymentLag");
+    notionalPaymentLag_ = XMLUtils::getChildValue(node, "NotionalPaymentLag", false, paymentLag_);
     paymentCalendar_ = XMLUtils::getChildValue(node, "PaymentCalendar", false);
     // if not given, default of getChildValueAsBool is true, which fits our needs here
     notionals_ = XMLUtils::getChildrenValuesWithAttributes<Real>(node, "Notionals", "Notional", "startDate",

--- a/OREData/ored/portfolio/legdata.cpp
+++ b/OREData/ored/portfolio/legdata.cpp
@@ -815,7 +815,7 @@ void LegData::fromXML(XMLNode* node) {
 
     // set payment calendar equal to the schedule calendar if the payment calendar not given
     // otherwise the payment calendar is not set and payments of notional can happen before the interest payments 
-    if (paymentCalendar_.empty()) {
+    if (paymentCalendar_.empty()  && !schedule_.rules().empty()) {
         auto tmp = schedule_.rules().front().calendar();
         if (!tmp.empty()) {
             paymentCalendar_ = tmp;


### PR DESCRIPTION
Generally the notional lag in swaps has the same lag as the coupon payment lag. to achieve these result I would propose to put the coupon payment lag as a default value in the notional payment lag. Otherwise one has to list both xml tags which is redundant.