### PR TITLE
Fix crash when parsing char as boolean for 'csvCommentReportHeader'

### DIFF
--- a/OREAnalytics/orea/app/oreapp.cpp
+++ b/OREAnalytics/orea/app/oreapp.cpp
@@ -846,8 +846,11 @@ void OREAppInputParameters::loadParameters() {
             LOG("MarketContext::" << m.first << " = " << m.second);
     }
 
-    if (params_->has("setup", "csvCommentReportHeader"))
-        setCsvCommentCharacter(parseBool(params_->get("setup", "csvCommentReportHeader")));
+    if (params_->has("setup", "csvCommentReportHeader")) {
+        tmp = params_->get("setup", "csvCommentReportHeader");
+        QL_REQUIRE(tmp.size() == 1, "csvCommentReportHeader must be exactly one character");
+        setCsvCommentCharacter(tmp[0]);
+    }
 
     if (params_->has("setup", "csvSeparator")) {
         tmp = params_->get("setup", "csvSeparator");


### PR DESCRIPTION
Hi,
There's a bug in the parsing of this parameter, where ORE will crash when provided with any character that isn't parsable as a boolean. Seems to be a copy-paste oversight, but it's fixable by following the parsing logic that the similar parameter 'csvSeparator' uses. :)

Kind regards,
Fredrik