### PR TITLE
Define and correctly spell SabrParametricVolatility calibration-grid axis accessors

### DIFF
--- a/QuantExt/qle/termstructures/sabrparametricvolatility.cpp
+++ b/QuantExt/qle/termstructures/sabrparametricvolatility.cpp
@@ -71,6 +71,10 @@ ParametricVolatility::MarketQuoteType SabrParametricVolatility::preferredOutputQ
     }
 }
 
+const std::vector<Real>& SabrParametricVolatility::timeToExpiries() const { return timeToExpiries_; }
+
+const std::vector<Real>& SabrParametricVolatility::underlyingLengths() const { return underlyingLengths_; }
+
 std::vector<Real> SabrParametricVolatility::getGuess(const std::vector<std::pair<Real, ParameterCalibration>>& params,
                                                      const std::vector<Real>& randomSeq, const Real forward,
                                                      const Real lognormalShift) const {

--- a/QuantExt/qle/termstructures/sabrparametricvolatility.hpp
+++ b/QuantExt/qle/termstructures/sabrparametricvolatility.hpp
@@ -60,10 +60,10 @@ public:
              const QuantLib::Real outputLognormalShift = QuantLib::Null<QuantLib::Real>(),
              const QuantLib::ext::optional<QuantLib::Option::Type> outputOptionType = QuantLib::ext::nullopt) const override;
 
-    // the calculated grid of option expiries and the underlying lenghts
-    const std::vector<Real>& timeToEpiries() const;
-    const std::vector<Real>& underlyingLenghts() const;
-    // calibrated or interpolated model parameters (rows = underlying lenghts, cols = option expiries)
+    // the calculated grid of option expiries and the underlying lengths
+    const std::vector<Real>& timeToExpiries() const;
+    const std::vector<Real>& underlyingLengths() const;
+    // calibrated or interpolated model parameters (rows = underlying lengths, cols = option expiries)
     const QuantLib::Matrix& alpha() const { return alpha_; }
     const QuantLib::Matrix& beta() const { return beta_; }
     const QuantLib::Matrix& nu() const { return nu_; }


### PR DESCRIPTION
## Summary

`SabrParametricVolatility` declares two accessors for its calibration-grid axes in `qle/termstructures/sabrparametricvolatility.hpp`:

```cpp
// the calculated grid of option expiries and the underlying lenghts
const std::vector<Real>& timeToEpiries() const;
const std::vector<Real>& underlyingLenghts() const;
```

Neither is defined in `sabrparametricvolatility.cpp` or anywhere else in the tree, so calling either one fails at link time with an undefined symbol. This PR:

- Defines both accessors to return the existing `timeToExpiries_` / `underlyingLengths_` members.
- Corrects the misspelled names — `timeToEpiries` → `timeToExpiries`, `underlyingLenghts` → `underlyingLengths` — along with the `lenghts` typos in the two adjacent comments.

### Why this matters

The class publicly exposes its calibration results as matrices — `alpha()`, `beta()`, `nu()`, `rho()`, `lognormalShift()`, `numberOfCalibrationAttempts()`, `calibrationError()`, `isInterpolated()` — laid out as rows = underlying lengths, cols = option expiries. Without the axis vectors, a caller cannot map a matrix cell back to the `(timeToExpiry, underlyingLength)` node it was calibrated at, which makes the matrices unusable for per-pillar calibration diagnostics or reporting.

### On the rename

Renaming a public accessor would normally be a source-breaking change. It is not one here: since neither function was ever defined, no code could have linked against the old spellings. Correcting them now is free; after the definitions ship it stops being free.

Happy to drop the rename and keep the original spellings if you would rather preserve the declared names verbatim — the definitions are the substantive part of the change.

## Test plan

- [x] `QuantExt` compiles and links cleanly with the change
- [x] Both symbols are present in the resulting `libQuantExt` binary
- [x] Repo-wide grep confirms no other references to the old spellings existed
