### PR TITLE
Finish the nose to pytest migration; repair Windows test script

### DIFF
--- a/Examples/ORE-API/run_examples_testsuite.py
+++ b/Examples/ORE-API/run_examples_testsuite.py
@@ -3,9 +3,7 @@ import os
 import shutil
 import sys
 import argparse
-import collections
-collections.Callable = collections.abc.Callable
-import nose
+import pytest
 import unittest
 import urllib
 import json
@@ -24,7 +22,7 @@ from Tools.PythonTools.setup_logging import setup_logging  # noqa
 class TestExamples(unittest.TestCase):
     def setUp(self):
         self.logger = logging.getLogger(__name__)
-    
+
     def runexample(self, name):
         self.logger.info('{}: run {}'.format(self._testMethodName, name))
         completed = False
@@ -64,7 +62,7 @@ class TestExamples(unittest.TestCase):
 
         else:
             return
-            #raise ValueError('Expected path ' + default_orexml_path + ' to exist.') 
+            #raise ValueError('Expected path ' + default_orexml_path + ' to exist.')
 
 def get_list_of_examples():
     examples_dir = os.path.normpath(Path(__file__).resolve().parents[1])
@@ -92,4 +90,4 @@ setup_logging()
 create_all_utests()
 
 if __name__ == '__main__':
-    nose.runmodule(name='__main__')
+    sys.exit(pytest.main([__file__]))

--- a/Examples/ORE-API/run_json_testsuite.py
+++ b/Examples/ORE-API/run_json_testsuite.py
@@ -3,9 +3,7 @@ import os
 import sys
 import shutil
 import argparse
-import collections
-collections.Callable = collections.abc.Callable
-import nose
+import pytest
 import unittest
 import urllib
 import json
@@ -40,7 +38,7 @@ class TestExamples(unittest.TestCase):
             return '/'.join(["http://127.0.0.1:5000/file" , full_encode])
         else:
             return path
-        
+
     def checkParam(self, value):
         fileToUri = {"marketDataFile": "marketData",
         "fixingDataFile": "fixingData",
@@ -96,7 +94,7 @@ class TestExamples(unittest.TestCase):
                     for child in analytic.findall('Parameter'):
                         param = self.checkParam(child.get('name'))
                         body["analytics"][analyticType][param] = child.text if str(param) in ignore else self.configureUri(input_dir, child.text)
-            
+
             partial_encode = urllib.parse.quote( os.path.abspath(output_dir), safe='')
             full_encode = urllib.parse.quote(partial_encode, safe='')
             report_dir = '/'.join(["http://127.0.0.1:5000/report" , full_encode])
@@ -105,9 +103,9 @@ class TestExamples(unittest.TestCase):
             response_file_name = 'payload.json'
             with open(os.path.join(output_dir, response_file_name), 'w') as json_file:
                 json.dump(body, json_file)
-            
+
             return body
-                    
+
     def runexample(self, name):
         self.logger.info('{}: run {}'.format(self._testMethodName, name))
         completed = False
@@ -176,4 +174,4 @@ setup_logging()
 create_all_utests()
 
 if __name__ == '__main__':
-    nose.runmodule(name='__main__')
+    sys.exit(pytest.main([__file__]))

--- a/ORE-SWIG/runPythonTests.cmd
+++ b/ORE-SWIG/runPythonTests.cmd
@@ -1,12 +1,21 @@
-set PYTHONPATH=%PYTHONPATH%;%~dp0\OREAnalytics-SWIG\Python\build;%~dp0\OREAnalytics-SWIG\Python\build\Release
+@echo off
+setlocal
+
+REM Run the Python test suites against a locally built ORE module.
+REM Picks up the setup.py build output; harmless no-op if you installed
+REM the package instead with `python setup.py install`.
+for /d %%d in ("%~dp0build\lib.*") do set "PYTHONPATH=%PYTHONPATH%;%%d"
+
+cd /d "%~dp0test"
+
 echo RUN ORE Python Testsuite
-cd %~dp0\OREAnalytics-SWIG\Python\Test
 python OREAnalyticsTestSuite.py
-pause
+if errorlevel 1 exit /b 1
 
+REM testrunner.py aliases QuantLib to ORE before collection, which the
+REM QuantLib-SWIG tests require; they import QuantLib, not ORE.
 echo RUN QuantLib Testsuite
-cd %~dp0\QuantLib-SWIG\Python\test
-python -c "import sys, ORE; sys.modules['QuantLib']=ORE;import QuantLibTestSuite;QuantLibTestSuite.test()"
-pause
+python testrunner.py
+if errorlevel 1 exit /b 1
 
-cd %~dp0\
+echo All Python test suites passed

--- a/ORE-SWIG/test/OREAnalyticsTestSuite.py
+++ b/ORE-SWIG/test/OREAnalyticsTestSuite.py
@@ -2,16 +2,17 @@
  Copyright (C) 2023 Quaternion Risk Management Ltd
  All rights reserved.
 """
+import os
 import sys
-import nose
+import pytest
 import ORE
 
 def test():
     print('testing ORED ' + ORE.__version__)
-    result = nose.run()
-    if result == False:
-        sys.exit(1)
+    exit_code = pytest.main([os.path.dirname(os.path.abspath(__file__))])
+    if exit_code != 0:
+        sys.exit(exit_code)
+
 
 if __name__ == '__main__':
     test()
-

--- a/ORE-SWIG/test/testrunner.py
+++ b/ORE-SWIG/test/testrunner.py
@@ -5,7 +5,11 @@ import pytest
 
 sys.modules["QuantLib"] = ORE
 
+QUANTLIB_TESTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              os.pardir, "QuantLib-SWIG", "Python", "test")
+
 if __name__=="__main__":
-    pytest_args = sys.argv[1:] or ["../QuantLibTestSuite"]
+    pytest_args = sys.argv[1:] or [QUANTLIB_TESTS]
     ret_code = pytest.main(pytest_args)
     print("PyTest Return Code: ", ret_code)
+    sys.exit(ret_code)

--- a/ORE-SWIG/tutorials.03.build_windows.md
+++ b/ORE-SWIG/tutorials.03.build_windows.md
@@ -92,7 +92,7 @@ setup.py.
     python -m venv env1
     .\env1\Scripts\activate.bat
     python -m pip install --upgrade pip
-    python -m pip install build pynose pytest setuptools
+    python -m pip install build pytest setuptools
     python setup.py wrap
     python setup.py build
     python setup.py test

--- a/tutorials/tutorials.030.docker.md
+++ b/tutorials/tutorials.030.docker.md
@@ -62,7 +62,7 @@ Invoke the command below to run the docker container interactively:
 Here are the commands to run the examples:
 
     cd /ore/Examples
-    python3 run_examples_testsuite.py --with-xunitmp --xunitmp-file=examples.xml --processes=8 --process-timeout=3600
+    pytest run_examples_testsuite.py --junitxml=examples.xml -n 8 --timeout=3600
 
 Here are the commands to run all of the unit tests in parallel:
 


### PR DESCRIPTION
## Summary

- Replaces the last three `nose` imports with `pytest`, in `Examples/ORE-API/run_examples_testsuite.py`, `Examples/ORE-API/run_json_testsuite.py`, and `ORE-SWIG/test/OREAnalyticsTestSuite.py`. Commit b40e46379 switched the project to pytest but these three were missed.
- Drops the `collections.Callable = collections.abc.Callable` shim, which existed only to keep nose importable on Python 3.10+.
- Keeps a module-level `test()` in `OREAnalyticsTestSuite.py`. `ORE-SWIG/setup.py` imports the module and calls `module.test()`, so removing it breaks `python setup.py test` — the workflow documented in `ORE-SWIG/tutorials.03.build_windows.md`. It exits non-zero from inside `test()` rather than returning a code, because that caller inspects no return value.
- Repairs `ORE-SWIG/runPythonTests.cmd`, which pointed at `OREAnalytics-SWIG\Python\build` and `OREAnalytics-SWIG\Python\Test`. Neither survived the move of the Python suite to `ORE-SWIG\test`, so every path in it was wrong. Its QuantLib block also called `QuantLibTestSuite.test()`, which disappeared when QuantLib-SWIG adopted plain pytest; it now delegates to `ORE-SWIG/test/testrunner.py`, the current entry point.
- Fixes `testrunner.py`'s default target, which named the same vanished `QuantLibTestSuite`. It now derives the QuantLib-SWIG test directory from `__file__` and propagates pytest's exit code instead of only printing it.
- Updates two tutorials that still referenced nose: `tutorials.03.build_windows.md` installed `pynose`, and `tutorials.030.docker.md` invoked the examples suite with nose plugin flags (`--with-xunitmp`, `--processes`, `--process-timeout`) that pytest rejects.

## Questions for maintainers

I'm not a maintainer and don't have a Windows machine, so a few decisions here are guesses. Happy to change any of them.

**1. `runPythonTests.cmd` is untested on Windows.** I verified path resolution and syntax, but the batch control flow has never been run. The part I'm least sure of is how `PYTHONPATH` should be derived. I glob the `setup.py` build output:

```bat
for /d %%d in ("%~dp0build\lib.*") do set "PYTHONPATH=%PYTHONPATH%;%%d"
```

That generalizes the version-pinned `build\lib.win-amd64-cpython-312` from `tutorials.03.build_windows.md` and no-ops for anyone who ran `python setup.py install`. If there's a canonical build layout I should target instead, I'll use it.

**2. Is `runPythonTests.cmd` meant to be double-clicked, or invoked?** I removed both `pause` calls and added `if errorlevel 1 exit /b 1`, so it now fails fast and returns a meaningful exit code. That makes it usable unattended but closes the window before you can read output when launched from Explorer. If interactive use is the point, I'll restore `pause` on the failure path.

**3. Should the two `Examples/ORE-API` suites be wired into CTest?** Nothing invokes them — `CMakeLists.txt` registers only `Examples/run_examples_testsuite.py`. That is likely why they sat on nose unnoticed after the migration. I've left them out of the build, but they'd stop silently rotting if added.

**4. Should `Examples/run_examples_testsuite.py` propagate its exit code?** Its `__main__` block prints the pytest return code without exiting on it, so `python3 run_examples_testsuite.py` reports success over failing tests. CTest is unaffected because it invokes `pytest` directly. It's pre-existing and outside this change's scope, so I left it alone — say the word and I'll fix it here.

**5. Is `setup.py`'s distutils-style `test` command still wanted?** I preserved its contract rather than reshaping it, but the command is deprecated in modern setuptools. If you'd rather it shelled out to pytest directly, `OREAnalyticsTestSuite.test()` could go away entirely.

## Test plan

- [x] `Examples/ORE-API/run_examples_testsuite.py` collects under pytest (14 tests) — the dynamically generated `Test_<name>` classes are still picked up, since they subclass `unittest.TestCase`
- [x] `ORE-SWIG/test/OREAnalyticsTestSuite.py` compiles and exposes `test()` at module level, so `setup.py:53`'s `module.test()` resolves
- [x] `testrunner.py` compiles; its new default resolves to `ORE-SWIG/QuantLib-SWIG/Python/test`, containing 35 test files
- [x] No `nose`, `nosetests`, `pynose`, `nose_xunitmp`, or `collections.Callable` references remain outside the `QuantLib` submodule
- [ ] `runPythonTests.cmd` runs both suites on Windows against a real build — **needs a reviewer with a Windows machine**
- [ ] `python setup.py test` succeeds on Windows
- [ ] Full `Examples/ORE-API` suite passes against a running ORE API server (needs the service on `127.0.0.1:5001`)

Everything unchecked needs an environment I don't have.
